### PR TITLE
Add Index Price from Coin Gecko

### DIFF
--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -14,12 +14,6 @@ export const DPI_ETH_UNISWAP_QUERY= gql`
       id
       reserveUSD
     }
-    bundle(id: "1") {
-      ethPrice
-    }
-    tokens(where: { id: "0x0954906da0Bf32d5479e25f46056d22f08464cab" }) {
-      derivedETH
-    }
   }
 `
 


### PR DESCRIPTION
The Graph is not indexing the INDEX token on Uniswap, either because the INDEX/ETH pair is too small, or because the token is recently launched

This PR fetches INDEX token price from the coingecko API