### PR TITLE
Dpi product

### DIFF
--- a/src/components/BuyToken/BuyTokenPlaceholder.tsx
+++ b/src/components/BuyToken/BuyTokenPlaceholder.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Card, CardContent } from 'react-neu'
+
+const BuyTokenPlaceholder: React.FC = () => {
+  return (
+    <Card>
+      <CenteredContent>
+        <BuyIcon
+          src={'https://index-dao.s3.amazonaws.com/defi_pulse_index_set.svg'}
+        />
+        <div>
+          <LargeText> Buy & Sell </LargeText>
+          <SmallText> Coming Soon </SmallText>
+        </div>
+      </CenteredContent>
+    </Card>
+  )
+}
+
+const CenteredContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin: auto;
+  padding: 32px 48px;
+
+  @media (min-width: 400px) {
+    flex-direction: column;
+    text-align: center;
+  }
+`
+
+const BuyIcon = styled.img`
+  margin-right: 16px;
+`
+
+const LargeText = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+`
+const SmallText = styled.div`
+  font-size: 20px;
+`
+
+export default BuyTokenPlaceholder

--- a/src/components/BuyToken/index.ts
+++ b/src/components/BuyToken/index.ts
@@ -1,0 +1,1 @@
+export { default as BuyTokenPlaceholder } from './BuyTokenPlaceholder'

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -40,15 +40,13 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
 
   const renderTooltip = (props: any) => {
     const tooltipData = props.payload?.[0]
-    readTooltipData && readTooltipData(tooltipData)
+
+    if (readTooltipData && tooltipData) readTooltipData(tooltipData)
+
     if (!showTooltip) return null
 
     const [label, value] = formatToolTip(tooltipData)
     return <FancyValue icon={icon} label={label} value={value} />
-  }
-
-  const onMouseMove = (props: any) => {
-    console.log('chart price hover', props)
   }
 
   const minY = Math.min(...(data || []).map<number>(({ y }) => y))
@@ -64,7 +62,6 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
             dot={false}
             stroke={'url(#gradient)'}
             strokeWidth={2}
-            onMouseMove={onMouseMove}
           />
           <YAxis
             stroke={theme.colors.grey[500]}

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -18,6 +18,7 @@ interface SimplePriceChartProps {
     x: string | number
     y: number
   }[]
+  readTooltipData?: Function
 }
 
 const MarketDataChart: React.FC<SimplePriceChartProps> = ({
@@ -25,6 +26,7 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   showTooltip,
   icon,
   data,
+  readTooltipData,
 }) => {
   const theme = useTheme()
   const formatFloats = (n: number) => parseFloat(numeral(n).format('0.00a'))
@@ -37,10 +39,16 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   }
 
   const renderTooltip = (props: any) => {
+    const tooltipData = props.payload?.[0]
+    readTooltipData && readTooltipData(tooltipData)
     if (!showTooltip) return null
 
-    const [label, value] = formatToolTip(props.payload?.[0])
+    const [label, value] = formatToolTip(tooltipData)
     return <FancyValue icon={icon} label={label} value={value} />
+  }
+
+  const onMouseMove = (props: any) => {
+    console.log('chart price hover', props)
   }
 
   const minY = Math.min(...(data || []).map<number>(({ y }) => y))
@@ -56,6 +64,7 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
             dot={false}
             stroke={'url(#gradient)'}
             strokeWidth={2}
+            onMouseMove={onMouseMove}
           />
           <YAxis
             stroke={theme.colors.grey[500]}

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -5,9 +5,18 @@ import { NavLink } from 'react-router-dom'
 const Nav: React.FC = () => {
   return (
     <StyledNav>
-      <StyledLink exact activeClassName="active" to="/">Home</StyledLink>
-      <StyledLink exact activeClassName="active" to="/farm">Farm</StyledLink>
-      <StyledLink activeClassName="active" to="/faq">FAQ</StyledLink>
+      <StyledLink exact activeClassName='active' to='/'>
+        Home
+      </StyledLink>
+      <StyledLink exact activeClassName='active' to='/dpi'>
+        DeFi Pulse Index
+      </StyledLink>
+      <StyledLink exact activeClassName='active' to='/farm'>
+        Farm
+      </StyledLink>
+      <StyledLink activeClassName='active' to='/faq'>
+        FAQ
+      </StyledLink>
     </StyledNav>
   )
 }
@@ -18,16 +27,16 @@ const StyledNav = styled.nav`
 `
 
 const StyledLink = styled(NavLink)`
-  color: ${props => props.theme.colors.grey[500]};
+  color: ${(props) => props.theme.colors.grey[500]};
   font-weight: 700;
-  padding-left: ${props => props.theme.spacing[3]}px;
-  padding-right: ${props => props.theme.spacing[3]}px;
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
   text-decoration: none;
   &:hover {
-    color: ${props => props.theme.colors.grey[600]};
+    color: ${(props) => props.theme.colors.grey[600]};
   }
   &.active {
-    color: ${props => props.theme.colors.primary.light};
+    color: ${(props) => props.theme.colors.primary.light};
   }
 `
 

--- a/src/views/DPI/DPI.tsx
+++ b/src/views/DPI/DPI.tsx
@@ -3,12 +3,18 @@ import { Container, Spacer } from 'react-neu'
 
 import Page from 'components/Page'
 import MarketData from './components/MarketData'
+import DpiHoldings from './components/DpiHoldings'
+import DpiPriceChanges from './components/DpiPriceChanges'
+import DpiTokenStats from './components/DpiTokenStats'
 
 const Home: React.FC = () => {
   return (
     <Page>
-      <Container size='lg'>
+      <Container>
         <MarketData />
+        <DpiHoldings />
+        <DpiPriceChanges />
+        <DpiTokenStats />
       </Container>
     </Page>
   )

--- a/src/views/DPI/DPI.tsx
+++ b/src/views/DPI/DPI.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Container, Spacer } from 'react-neu'
 
 import Page from 'components/Page'
+import { BuyTokenPlaceholder } from 'components/BuyToken'
 import MarketData from './components/MarketData'
 import DpiHoldings from './components/DpiHoldings'
 import DpiPriceChanges from './components/DpiPriceChanges'
@@ -12,6 +13,7 @@ const Home: React.FC = () => {
     <Page>
       <Container>
         <MarketData />
+        <BuyTokenPlaceholder />
         <DpiHoldings />
         <DpiPriceChanges />
         <DpiTokenStats />

--- a/src/views/DPI/components/DpiHoldings.tsx
+++ b/src/views/DPI/components/DpiHoldings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
 
@@ -17,7 +17,6 @@ const DpiHoldings: React.FC = () => {
         ${numeral((latestPrice || 0) * Number(dpiBalance)).format('0.00a')}
       </BaseCurrencyDpiValuation>
       <DpiTokenHoldings>
-        {' '}
         {numeral(dpiBalance).format('0.000a')} DPI
       </DpiTokenHoldings>
     </InfoSection>

--- a/src/views/DPI/components/DpiHoldings.tsx
+++ b/src/views/DPI/components/DpiHoldings.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
+import numeral from 'numeral'
+
+import InfoSection from './InfoSection'
+
+import useBalances from 'hooks/useBalances'
+import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
+
+const DpiHoldings: React.FC = () => {
+  const { dpiBalance } = useBalances()
+  const { latestPrice } = useDpiTokenMarketData()
+  console.log('DPI assets', Number(dpiBalance), latestPrice)
+  return (
+    <InfoSection title='My Assets'>
+      <BaseCurrencyDpiValuation>
+        ${numeral((latestPrice || 0) * Number(dpiBalance)).format('0.00a')}
+      </BaseCurrencyDpiValuation>
+      <DpiTokenHoldings>
+        {' '}
+        {numeral(dpiBalance).format('0.000a')} DPI
+      </DpiTokenHoldings>
+    </InfoSection>
+  )
+}
+
+const BaseCurrencyDpiValuation = styled.h3`
+  display: inline-block;
+  margin: 0 ${({ theme }) => theme.spacing[4]}px 0 0;
+  font-size: 28px;
+`
+
+const DpiTokenHoldings = styled.div`
+  display: inline-block;
+  font-size: 16px;
+  color: ${({ theme }) => theme.colors.grey[500]};
+`
+
+export default DpiHoldings

--- a/src/views/DPI/components/DpiPriceChanges.tsx
+++ b/src/views/DPI/components/DpiPriceChanges.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode } from 'react'
+import React, { ReactNode } from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
 
@@ -38,7 +38,7 @@ const DpiPriceChanges: React.FC = () => {
   const renderPriceChanges = (config: any) => {
     const [dateString, daysOfComparison] = config // how to destructure in params without tsx bitching?
     return (
-      <StyledPriceChange>
+      <StyledPriceChange key={daysOfComparison}>
         <StyledDateString>{dateString}</StyledDateString>
         {calculatePriceDiffs(daysOfComparison)}
       </StyledPriceChange>

--- a/src/views/DPI/components/DpiPriceChanges.tsx
+++ b/src/views/DPI/components/DpiPriceChanges.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect, ReactNode } from 'react'
+import styled from 'styled-components'
+import numeral from 'numeral'
+
+import InfoSection from './InfoSection'
+
+import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
+
+const DpiPriceChanges: React.FC = () => {
+  const { prices } = useDpiTokenMarketData()
+  const [startTime] = prices?.[0] || [0]
+  const [latestTime, latestPrice] = prices?.[prices.length - 1] || [0, 0]
+  // Coingecko API returns each item as hourly data if < 90 days and daily data > 90 days
+  // So if time between start and end time < 90 days, 1 day of data is 24 array items.
+  const dataCadenceFor24Hours = latestTime - startTime < 7776000000 ? 24 : 1
+  const priceChangeIntervals = [
+    ['1 Day', 1],
+    ['1 Month', 30],
+    ['3 Months', 90],
+    ['1 Year', 365],
+  ]
+
+  const calculatePriceDiffs = (daysOfComparison: number) => {
+    // placeholder if no data available for timerange
+    if (!prices || prices.length < daysOfComparison * dataCadenceFor24Hours)
+      return <div>---</div>
+    const startPriceIndex =
+      prices.length - daysOfComparison * dataCadenceFor24Hours
+    const startPrice = prices[startPriceIndex][1]
+    const priceDiff = ((latestPrice - startPrice) / startPrice) * 100
+    const StyledPrice =
+      priceDiff < 0 ? StyledNegativePrice : StyledPositivePrice
+    return (
+      <StyledPrice>{numeral(priceDiff).format('+0.00a') + '%'}</StyledPrice>
+    )
+  }
+
+  const renderPriceChanges = (config: any) => {
+    const [dateString, daysOfComparison] = config // how to destructure in params without tsx bitching?
+    return (
+      <StyledPriceChange>
+        <StyledDateString>{dateString}</StyledDateString>
+        {calculatePriceDiffs(daysOfComparison)}
+      </StyledPriceChange>
+    )
+  }
+
+  return (
+    <InfoSection title='Changes'>
+      <PriceChangesContainer>
+        {priceChangeIntervals.map<ReactNode>(renderPriceChanges)}
+      </PriceChangesContainer>
+    </InfoSection>
+  )
+}
+
+const PriceChangesContainer = styled.div`
+  display: flex;
+`
+const StyledPriceChange = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`
+const StyledDateString = styled.div`
+  font-size: 16px;
+  margin-bottom: 16px;
+`
+
+const StyledNegativePrice = styled.div`
+  color: red;
+`
+
+const StyledPositivePrice = styled.div`
+  color: green;
+`
+
+export default DpiPriceChanges

--- a/src/views/DPI/components/DpiTokenStats.tsx
+++ b/src/views/DPI/components/DpiTokenStats.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
 

--- a/src/views/DPI/components/DpiTokenStats.tsx
+++ b/src/views/DPI/components/DpiTokenStats.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect, ReactNode } from 'react'
+import styled from 'styled-components'
+import numeral from 'numeral'
+
+import InfoSection from './InfoSection'
+
+import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
+
+const DpiPriceChanges: React.FC = () => {
+  const { latestPrice, latestVolume, latestMarketCap } = useDpiTokenMarketData()
+
+  return (
+    <InfoSection title='Stats'>
+      <PriceStatsContainer>
+        <StyledStat>
+          <StyledStatTitle>Market Cap</StyledStatTitle>
+          <StyledStatMetric>
+            ${numeral(latestMarketCap).format('0.00a')}
+          </StyledStatMetric>
+        </StyledStat>
+        <StyledStat>
+          <StyledStatTitle>Volume</StyledStatTitle>
+          <StyledStatMetric>
+            ${numeral(latestVolume).format('0.00a')}
+          </StyledStatMetric>
+        </StyledStat>
+        <StyledStat>
+          <StyledStatTitle>Current Supply</StyledStatTitle>
+          <StyledStatMetric>
+            {numeral((latestMarketCap || 0) / (latestPrice || 1)).format('0,0')}
+          </StyledStatMetric>
+        </StyledStat>
+      </PriceStatsContainer>
+    </InfoSection>
+  )
+}
+
+const PriceStatsContainer = styled.div`
+  display: flex;
+`
+const StyledStat = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`
+const StyledStatTitle = styled.div`
+  font-size: 16px;
+`
+const StyledStatMetric = styled.div`
+  font-size: 24px;
+`
+
+export default DpiPriceChanges

--- a/src/views/DPI/components/InfoSection.tsx
+++ b/src/views/DPI/components/InfoSection.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface InfoSectionProps {
+  title: string
+}
+
+const InfoSection: React.FC<InfoSectionProps> = ({ title, children }) => {
+  return (
+    <SectionContainer>
+      <SectionTitle>{title}</SectionTitle>
+      {children}
+    </SectionContainer>
+  )
+}
+
+const SectionContainer = styled.div`
+  padding: ${({ theme }) => theme.spacing[6]}px 0;
+
+  :not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.grey[400]};
+  }
+`
+
+const SectionTitle = styled.h3`
+  font-size: 28px;
+  margin-top: 0;
+  color: ${({ theme }) => theme.textColor};
+`
+export default InfoSection

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
 import { Container, Card, CardContent, Spacer } from 'react-neu'
@@ -8,6 +8,7 @@ import Split from 'components/Split'
 import SimplePriceChart from 'components/SimplePriceChart'
 
 import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
+import useBalances from 'hooks/useBalances'
 
 const MarketData: React.FC = () => {
   const {
@@ -16,13 +17,21 @@ const MarketData: React.FC = () => {
     latestPrice,
     prices,
   } = useDpiTokenMarketData()
+  const [chartPrice, setChartPrice] = useState<number>(0)
+  useEffect(() => {
+    if (!chartPrice && latestPrice) setChartPrice(latestPrice)
+  })
+
+  if (!chartPrice && latestPrice) setChartPrice(latestPrice)
   const priceAtEpochStart = prices?.[0]?.[1] || 1
-  const epochPriceChange = (latestPrice || 0) - priceAtEpochStart
+  const epochPriceChange = (chartPrice || 0) - priceAtEpochStart
   const dpiTokenIcon = {
     src: 'https://index-dao.s3.amazonaws.com/defi_pulse_index_set.svg',
     alt: 'DefiPulse Index Logo',
   }
-
+  const updateChartPrice = (tooltipData: any) => {
+    if (tooltipData) return setChartPrice(tooltipData.payload.y)
+  }
   return (
     <>
       <Card>
@@ -34,7 +43,7 @@ const MarketData: React.FC = () => {
           <StyledDpiTitle>DeFi Pulse Index</StyledDpiTitle>
           <StyledDpiPriceWrapper>
             <StyledDpiPrice>
-              {'$' + numeral(latestPrice).format('0.00a')}
+              {'$' + numeral(chartPrice).format('0.00a')}
             </StyledDpiPrice>
             <StyledDpiPriceChange>
               {numeral((epochPriceChange / priceAtEpochStart) * 100).format(
@@ -46,6 +55,7 @@ const MarketData: React.FC = () => {
         <SimplePriceChart
           icon={dpiTokenIcon}
           data={prices?.map(([x, y]) => ({ x, y }))}
+          readTooltipData={updateChartPrice}
         />
       </Card>
     </>

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -1,37 +1,28 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
-import { Container, Card, CardContent, Spacer } from 'react-neu'
 
-import FancyValue from 'components/FancyValue'
-import Split from 'components/Split'
 import SimplePriceChart from 'components/SimplePriceChart'
 
 import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
-import useBalances from 'hooks/useBalances'
 
 const MarketData: React.FC = () => {
-  const {
-    latestVolume,
-    latestMarketCap,
-    latestPrice,
-    prices,
-  } = useDpiTokenMarketData()
+  const { latestPrice, prices } = useDpiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   useEffect(() => {
-    if (!chartPrice && latestPrice) setChartPrice(latestPrice)
+    if (!chartPrice && latestPrice) return setChartPrice(latestPrice)
   })
 
-  if (!chartPrice && latestPrice) setChartPrice(latestPrice)
   const priceAtEpochStart = prices?.[0]?.[1] || 1
   const epochPriceChange = (chartPrice || 0) - priceAtEpochStart
   const dpiTokenIcon = {
     src: 'https://index-dao.s3.amazonaws.com/defi_pulse_index_set.svg',
     alt: 'DefiPulse Index Logo',
   }
-  const updateChartPrice = (tooltipData: any) => {
-    if (tooltipData) return setChartPrice(tooltipData.payload.y)
-  }
+
+  const updateChartPrice = (tooltipData: any) =>
+    setChartPrice(tooltipData.payload.y)
+
   return (
     <>
       <StyledDpiIconLabel>

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -34,30 +34,26 @@ const MarketData: React.FC = () => {
   }
   return (
     <>
-      <Card>
-        <CardContent>
-          <StyledDpiIconLabel>
-            <StyledIcon src={dpiTokenIcon.src} alt={dpiTokenIcon.alt} />
-            <span>DPI</span>
-          </StyledDpiIconLabel>
-          <StyledDpiTitle>DeFi Pulse Index</StyledDpiTitle>
-          <StyledDpiPriceWrapper>
-            <StyledDpiPrice>
-              {'$' + numeral(chartPrice).format('0.00a')}
-            </StyledDpiPrice>
-            <StyledDpiPriceChange>
-              {numeral((epochPriceChange / priceAtEpochStart) * 100).format(
-                '0.00a'
-              ) + '%'}
-            </StyledDpiPriceChange>
-          </StyledDpiPriceWrapper>
-        </CardContent>
-        <SimplePriceChart
-          icon={dpiTokenIcon}
-          data={prices?.map(([x, y]) => ({ x, y }))}
-          readTooltipData={updateChartPrice}
-        />
-      </Card>
+      <StyledDpiIconLabel>
+        <StyledIcon src={dpiTokenIcon.src} alt={dpiTokenIcon.alt} />
+        <span>DPI</span>
+      </StyledDpiIconLabel>
+      <StyledDpiTitle>DeFi Pulse Index</StyledDpiTitle>
+      <StyledDpiPriceWrapper>
+        <StyledDpiPrice>
+          {'$' + numeral(chartPrice).format('0.00a')}
+        </StyledDpiPrice>
+        <StyledDpiPriceChange>
+          {numeral((epochPriceChange / priceAtEpochStart) * 100).format(
+            '0.00a'
+          ) + '%'}
+        </StyledDpiPriceChange>
+      </StyledDpiPriceWrapper>
+      <SimplePriceChart
+        icon={dpiTokenIcon}
+        data={prices?.map(([x, y]) => ({ x, y }))}
+        readTooltipData={updateChartPrice}
+      />
     </>
   )
 }


### PR DESCRIPTION
Don't have permissions on repo so can't push directly to branch :/
Adds:
* chart price/percentage updates when scrolling over chart
* all token stat components from design. Only missing the About text section, will throw that in after review
* adds /dpi to nav menu. Doesn't change links on homepage, v2 spec says "buy" buttons point there but we don't have buying yet so left as is.
* Placeholder "buy" button on DPI page. Have some design/product questions before I finish up the layout aspect of it.

Missing some design assets to finish off the spec:
* Mono font for chart prices
* hsl/hex/rgba codes for red/green prices
* Icon assets for buy/sell button

Getting a warning on chart price update function: `Cannot update component 'MarketData' from other component 'Tooltip'`
It only occurs once you start scrolling on the chart, not on initial render, and even if I did checks on the data to prevent potentially unnecessary updates.  It's only a warning but seemed to have a noticeable impact on chart rendering performance even when I ran a built version of the site so I'll do some digging. Chose to use the `readTooltipData` the other functions exposed by the chart e.g. onMouseMove don't actually tell you the actual x,y values where the mouse is but I might find a better solution while I'm fixing the issue.
