### PR TITLE
Add docs link to navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/MobileMenu/MobileMenu.tsx
+++ b/src/components/MobileMenu/MobileMenu.tsx
@@ -37,6 +37,12 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ onDismiss, visible }) => {
           <StyledLink activeClassName='active' to='/faq' onClick={onDismiss}>
             FAQ
           </StyledLink>
+          <StyledOutboundLink
+            href='https://docs.indexcoop.com/'
+            target='_blank'
+          >
+            Docs
+          </StyledOutboundLink>
         </StyledMobileMenu>
       </StyledMobileMenuWrapper>
     )
@@ -89,6 +95,24 @@ const StyledMobileMenu = styled.div`
 `
 
 const StyledLink = styled(NavLink)`
+  box-sizing: border-box;
+  color: ${(props) => props.theme.colors.grey[500]};
+  font-size: 24px;
+  font-weight: 700;
+  padding: ${(props) => props.theme.spacing[3]}px
+    ${(props) => props.theme.spacing[4]}px;
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+  &:hover {
+    color: ${(props) => props.theme.colors.grey[600]};
+  }
+  &.active {
+    color: ${(props) => props.theme.colors.primary.main};
+  }
+`
+
+const StyledOutboundLink = styled.a`
   box-sizing: border-box;
   color: ${(props) => props.theme.colors.grey[500]};
   font-size: 24px;

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -50,8 +50,6 @@ const StyledLink = styled(NavLink)`
 `
 
 const StyledOutboundLink = styled.a`
-  align-items: center;
-  display: flex;
   color: ${(props) => props.theme.colors.grey[500]};
   font-weight: 700;
   padding-left: ${(props) => props.theme.spacing[3]}px;

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -23,6 +23,9 @@ const Nav: React.FC = () => {
       <StyledLink activeClassName='active' to='/faq'>
         FAQ
       </StyledLink>
+      <StyledOutboundLink href='https://docs.indexcoop.com/' target='_blank'>
+        Docs
+      </StyledOutboundLink>
     </StyledNav>
   )
 }
@@ -33,6 +36,22 @@ const StyledNav = styled.nav`
 `
 
 const StyledLink = styled(NavLink)`
+  color: ${(props) => props.theme.colors.grey[500]};
+  font-weight: 700;
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
+  text-decoration: none;
+  &:hover {
+    color: ${(props) => props.theme.colors.grey[600]};
+  }
+  &.active {
+    color: ${(props) => props.theme.colors.primary.light};
+  }
+`
+
+const StyledOutboundLink = styled.a`
+  align-items: center;
+  display: flex;
   color: ${(props) => props.theme.colors.grey[500]};
   font-weight: 700;
   padding-left: ${(props) => props.theme.spacing[3]}px;


### PR DESCRIPTION
I noticed that there was no link to the docs on the website, and had a bit of difficulty finding it myself. This PR adds a Docs link under the main navbar. Alternatively, I could move it to the footer.