### PR TITLE
Add buttons for 1D, 1W, and 1M price charts

### DIFF
--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -54,13 +54,15 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   const [price, setPrice] = useState(data)
 
   useEffect(() => {
-    if (durationSelector === 0) {
-      setPrice(data?.slice((data?.length * 29) / 30))
-    } else if (durationSelector === 1) {
-      setPrice(data?.slice((data?.length * 23) / 30))
-    } else if (durationSelector === 2) {
-      setPrice(data)
-    }
+    setTimeout(() => {
+      if (durationSelector === 0) {
+        setPrice(data?.slice((data?.length * 29) / 30))
+      } else if (durationSelector === 1) {
+        setPrice(data?.slice((data?.length * 23) / 30))
+      } else if (durationSelector === 2) {
+        setPrice(data)
+      }
+    }, 0)
   }, [durationSelector, data])
 
   const handleDailyButton = () => {

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -21,16 +21,17 @@ interface SimplePriceChartProps {
   }[]
   onMouseMove?: (...args: any[]) => any
   onMouseLeave?: (...args: any[]) => any
+  setIsDaily?: (...args: any[]) => any
 }
 
 const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   title,
   showTooltip,
-  showDurations,
   icon,
   data,
   onMouseMove = () => {},
   onMouseLeave = () => {},
+  setIsDaily = () => {},
 }) => {
   const theme = useTheme()
   const formatFloats = (n: number) => parseFloat(numeral(n).format('0.00a'))
@@ -39,7 +40,14 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
     const {
       payload: { x, y },
     } = chartData
-    return [new Date(x).toLocaleDateString(), '$' + formatFloats(y)]
+    let timeString = new Date(x).toLocaleDateString()
+    if (durationSelector === 0) {
+      timeString = new Date(x).toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: 'numeric',
+      })
+    }
+    return [timeString, '$' + formatFloats(y)]
   }
 
   const [durationSelector, setDurationSelector] = useState<number>(2)
@@ -57,12 +65,15 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
 
   const handleDailyButton = () => {
     setDurationSelector(0)
+    setIsDaily(true)
   }
   const handleWeeklyButton = () => {
     setDurationSelector(1)
+    setIsDaily(false)
   }
   const handleMonthlyButton = () => {
     setDurationSelector(2)
+    setIsDaily(false)
   }
 
   const renderTooltip = (props: any) => {

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Container, useTheme } from 'react-neu'
+import React, { useEffect, useState } from 'react'
+import { Container, useTheme, Button, Spacer } from 'react-neu'
 import numeral from 'numeral'
 import styled from 'styled-components'
 
@@ -10,6 +10,7 @@ import { ResponsiveContainer, LineChart, Line, YAxis, Tooltip } from 'recharts'
 interface SimplePriceChartProps {
   title?: string
   showTooltip?: boolean
+  showDurations?: boolean
   icon: {
     src: string
     alt: string
@@ -25,6 +26,7 @@ interface SimplePriceChartProps {
 const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   title,
   showTooltip,
+  showDurations,
   icon,
   data,
   onMouseMove = () => {},
@@ -40,6 +42,29 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
     return [new Date(x).toLocaleDateString(), '$' + formatFloats(y)]
   }
 
+  const [durationSelector, setDurationSelector] = useState<number>(2)
+  const [price, setPrice] = useState(data)
+
+  useEffect(() => {
+    if (durationSelector === 0) {
+      setPrice(data?.slice((data?.length * 29) / 30))
+    } else if (durationSelector === 1) {
+      setPrice(data?.slice((data?.length * 23) / 30))
+    } else if (durationSelector === 2) {
+      setPrice(data)
+    }
+  }, [durationSelector, data])
+
+  const handleDailyButton = () => {
+    setDurationSelector(0)
+  }
+  const handleWeeklyButton = () => {
+    setDurationSelector(1)
+  }
+  const handleMonthlyButton = () => {
+    setDurationSelector(2)
+  }
+
   const renderTooltip = (props: any) => {
     if (!showTooltip) return null
 
@@ -49,8 +74,8 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
     return <FancyValue icon={icon} label={label} value={value} />
   }
 
-  const minY = Math.min(...(data || []).map<number>(({ y }) => y))
-  const maxY = Math.max(...(data || []).map<number>(({ y }) => y))
+  const minY = Math.min(...(price || []).map<number>(({ y }) => y))
+  const maxY = Math.max(...(price || []).map<number>(({ y }) => y))
   const minimumYAxisLabel = minY - 5 > 0 ? minY - 5 : 0
 
   return (
@@ -58,7 +83,7 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
       {title && <ChartTitle>{title}</ChartTitle>}
       <ChartContainer>
         <LineChart
-          data={data}
+          data={price}
           onMouseMove={onMouseMove}
           onMouseLeave={onMouseLeave}
         >
@@ -92,6 +117,31 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
           </defs>
         </LineChart>
       </ChartContainer>
+      <div style={{ float: 'right', display: 'flex', paddingBottom: '20px' }}>
+        <Button
+          full
+          size={'sm'}
+          text='1D'
+          variant={durationSelector === 0 ? 'default' : 'secondary'}
+          onClick={handleDailyButton}
+        />
+        <Spacer size={'sm'} />
+        <Button
+          full
+          size={'sm'}
+          text='1W'
+          variant={durationSelector === 1 ? 'default' : 'secondary'}
+          onClick={handleWeeklyButton}
+        />
+        <Spacer size={'sm'} />
+        <Button
+          full
+          size={'sm'}
+          text='1M'
+          variant={durationSelector === 2 ? 'default' : 'secondary'}
+          onClick={handleMonthlyButton}
+        />
+      </div>
     </Container>
   )
 }
@@ -102,6 +152,20 @@ const ChartContainer = styled(ResponsiveContainer)`
 
 const ChartTitle = styled.h2`
   font-size: 42px;
+`
+
+const DurationButton = styled.button`
+  background-color: radial-gradient(
+    circle at center top,
+    rgb(22, 20, 31),
+    rgb(22, 20, 31)
+  );
+  border: none;
+  border-radius: 50px;
+  margin: 8px;
+  padding: 0 0 10 10 px;
+  font-size: 1em;
+  color: white;
 `
 
 export default MarketDataChart

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -10,6 +10,8 @@ const MarketData: React.FC = () => {
   const { latestPrice, prices } = useDpiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
+  const [isDaily, setIsDaily] = useState<Boolean>(false)
+  const [dateString, setDateString] = useState<String>('')
 
   useEffect(() => {
     if (latestPrice) setChartPrice(latestPrice)
@@ -29,6 +31,14 @@ const MarketData: React.FC = () => {
       setChartPrice(payload.y || 0)
       setChartDate(payload.x || Date.now())
     }, 0)
+
+    if (isDaily) {
+      setDateString(
+        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
+      )
+    } else {
+      setDateString(priceData.toDateString())
+    }
   }
 
   const resetChartPrice = () => {
@@ -36,6 +46,14 @@ const MarketData: React.FC = () => {
       setChartPrice(latestPrice || 0)
       setChartDate(Date.now())
     }, 0)
+
+    if (isDaily) {
+      setDateString(
+        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
+      )
+    } else {
+      setDateString(priceData.toDateString())
+    }
   }
 
   const priceData = new Date(chartDate)
@@ -47,7 +65,7 @@ const MarketData: React.FC = () => {
         <span>DPI</span>
       </StyledDpiIconLabel>
       <StyledDpiTitle>DeFi Pulse Index</StyledDpiTitle>
-      <p>{priceData.toDateString()}</p>
+      <p>{dateString}</p>
       <StyledDpiPriceWrapper>
         <StyledDpiPrice>
           {'$' + numeral(chartPrice).format('0.00a')}
@@ -63,6 +81,7 @@ const MarketData: React.FC = () => {
         data={prices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
+        setIsDaily={setIsDaily}
       />
     </div>
   )

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -30,30 +30,36 @@ const MarketData: React.FC = () => {
     setTimeout(() => {
       setChartPrice(payload.y || 0)
       setChartDate(payload.x || Date.now())
-    }, 0)
 
-    if (isDaily) {
-      setDateString(
-        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
-      )
-    } else {
-      setDateString(priceData.toDateString())
-    }
+      if (isDaily) {
+        setDateString(
+          priceData.toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: 'numeric',
+          })
+        )
+      } else {
+        setDateString(priceData.toDateString())
+      }
+    }, 0)
   }
 
   const resetChartPrice = () => {
     setTimeout(() => {
       setChartPrice(latestPrice || 0)
       setChartDate(Date.now())
-    }, 0)
 
-    if (isDaily) {
-      setDateString(
-        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
-      )
-    } else {
-      setDateString(priceData.toDateString())
-    }
+      if (isDaily) {
+        setDateString(
+          priceData.toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: 'numeric',
+          })
+        )
+      } else {
+        setDateString(priceData.toDateString())
+      }
+    }, 0)
   }
 
   const priceData = new Date(chartDate)

--- a/src/views/Home/components/Integrations.tsx
+++ b/src/views/Home/components/Integrations.tsx
@@ -17,7 +17,7 @@ const Integrations: React.FC = () => (
               <StyledCardIcon src='https://index-dao.s3.amazonaws.com/owl.png' />
               <StyledCardTitle>Index Coop</StyledCardTitle>
               <StyledCardDescription>
-                Earn INDEX tokens be staking Uniswap ETH/DPI LP tokens.
+                Earn INDEX tokens by staking Uniswap ETH/DPI LP tokens.
               </StyledCardDescription>
 
               <StyledOutboundLink href='/farm'>
@@ -405,7 +405,7 @@ const StyledCardRow = styled.div`
 `
 
 const StyledCardContainer = styled.div`
-  width: 30%;
+  flex: 1;
   margin-bottom: 20px;
   @media (max-width: 768px) {
     width: 100%;
@@ -414,7 +414,7 @@ const StyledCardContainer = styled.div`
 
 const StyledFixedCardContainer = styled.div`
   height: 300px;
-  width: 30%;
+  flex: 1;
   margin-bottom: 50px;
   @media (max-width: 768px) {
     width: 100%;

--- a/src/views/Home/components/Integrations.tsx
+++ b/src/views/Home/components/Integrations.tsx
@@ -356,9 +356,9 @@ const Integrations: React.FC = () => (
             </StyledCardContent>
           </Surface>
         </StyledCardContainer>
+      </StyledCardRow>
 
-        <Spacer />
-
+      <StyledCardRow>
         <StyledCardContainer>
           <Surface fill>
             <StyledCardContent>
@@ -377,9 +377,11 @@ const Integrations: React.FC = () => (
             </StyledCardContent>
           </Surface>
         </StyledCardContainer>
+        <Spacer />
+        <StyledCardContainer></StyledCardContainer>
+        <Spacer />
+        <StyledCardContainer></StyledCardContainer>
       </StyledCardRow>
-
-      <Spacer />
     </StyledIntegrationsContainer>
   </div>
 )

--- a/src/views/INDEX/components/MarketData.tsx
+++ b/src/views/INDEX/components/MarketData.tsx
@@ -10,6 +10,8 @@ const MarketData: React.FC = () => {
   const { latestPrice, prices } = useIndexTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
+  const [isDaily, setIsDaily] = useState<Boolean>(false)
+  const [dateString, setDateString] = useState<String>('')
 
   useEffect(() => {
     if (latestPrice) setChartPrice(latestPrice)
@@ -29,6 +31,14 @@ const MarketData: React.FC = () => {
       setChartPrice(payload.y || 0)
       setChartDate(payload.x || Date.now())
     }, 0)
+
+    if (isDaily) {
+      setDateString(
+        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
+      )
+    } else {
+      setDateString(priceData.toDateString())
+    }
   }
 
   const resetChartPrice = () => {
@@ -36,6 +46,14 @@ const MarketData: React.FC = () => {
       setChartPrice(latestPrice || 0)
       setChartDate(Date.now())
     }, 0)
+
+    if (isDaily) {
+      setDateString(
+        priceData.toLocaleTimeString([], { hour: 'numeric', minute: 'numeric' })
+      )
+    } else {
+      setDateString(priceData.toDateString())
+    }
   }
 
   const priceData = new Date(chartDate)
@@ -47,7 +65,7 @@ const MarketData: React.FC = () => {
         <span>INDEX</span>
       </StyledDpiIconLabel>
       <StyledDpiTitle>Index Coop Token</StyledDpiTitle>
-      <p>{priceData.toDateString()}</p>
+      <p>{dateString}</p>
       <StyledDpiPriceWrapper>
         <StyledDpiPrice>
           {'$' + numeral(chartPrice).format('0.00a')}
@@ -63,6 +81,7 @@ const MarketData: React.FC = () => {
         data={prices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
+        setIsDaily={setIsDaily}
       />
     </div>
   )


### PR DESCRIPTION
## Changes
- Price charts have buttons for different timeframes
- On the 1D timeframe, dates are replaced with time using the `hh:mm` format