### PR TITLE
Add "add to metamask" button

### DIFF
--- a/src/components/ProductPage/ProductWalletBalance.tsx
+++ b/src/components/ProductPage/ProductWalletBalance.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
+import { Container, useTheme, Button, Spacer } from 'react-neu'
 import styled from 'styled-components'
 import numeral from 'numeral'
 import BigNumber from 'bignumber.js'
 
 import { ProductPageSection } from './ProductPageLayouts'
+import { useAddToMetamask } from 'hooks/useAddToMetamask'
+import useWallet from 'hooks/useWallet'
 
 interface ProductWalletBalanceProps {
-  symbol?: string
+  symbol: string
   latestPrice?: number
   currentBalance?: BigNumber | number
 }
@@ -16,14 +19,30 @@ const ProductWalletBalance: React.FC<ProductWalletBalanceProps> = ({
   latestPrice = 0,
   currentBalance = 0,
 }) => {
+  const wallet = useWallet()
+  const handleAddToMetamask = useAddToMetamask()
+
   return (
     <ProductPageSection title='My Assets'>
-      <StyledTokenValuation>
-        ${numeral(latestPrice * Number(currentBalance)).format('0.00a')}
-      </StyledTokenValuation>
-      <StyledTokenBalance>
-        {numeral(currentBalance).format('0.000a')} {symbol}
-      </StyledTokenBalance>
+      <div>
+        <StyledTokenValuation>
+          ${numeral(latestPrice * Number(currentBalance)).format('0.00a')}
+        </StyledTokenValuation>
+        <StyledTokenBalance>
+          {numeral(currentBalance).format('0.000a')} {symbol}
+        </StyledTokenBalance>
+      </div>
+      <br />
+      <AddToMetamask>
+        <Button
+          full
+          size={'sm'}
+          text='Add to Metamask'
+          variant={'default'}
+          disabled={wallet.ethereum == undefined}
+          onClick={() => handleAddToMetamask(symbol)}
+        />
+      </AddToMetamask>
     </ProductPageSection>
   )
 }
@@ -38,6 +57,11 @@ const StyledTokenBalance = styled.div`
   display: inline-block;
   font-size: 16px;
   color: ${({ theme }) => theme.colors.grey[500]};
+`
+
+const AddToMetamask = styled.div`
+  display: inline-block;
+  float: left;
 `
 
 export default ProductWalletBalance

--- a/src/components/ProductPage/ProductWalletBalance.tsx
+++ b/src/components/ProductPage/ProductWalletBalance.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Container, useTheme, Button, Spacer } from 'react-neu'
+import { Button } from 'react-neu'
 import styled from 'styled-components'
 import numeral from 'numeral'
 import BigNumber from 'bignumber.js'

--- a/src/components/ProductPage/ProductWalletBalance.tsx
+++ b/src/components/ProductPage/ProductWalletBalance.tsx
@@ -31,18 +31,17 @@ const ProductWalletBalance: React.FC<ProductWalletBalanceProps> = ({
         <StyledTokenBalance>
           {numeral(currentBalance).format('0.000a')} {symbol}
         </StyledTokenBalance>
+        <AddToMetamask>
+          <Button
+            full
+            size={'sm'}
+            text='Add to Metamask'
+            variant={'default'}
+            disabled={wallet.ethereum == undefined}
+            onClick={() => handleAddToMetamask(symbol)}
+          />
+        </AddToMetamask>
       </div>
-      <br />
-      <AddToMetamask>
-        <Button
-          full
-          size={'sm'}
-          text='Add to Metamask'
-          variant={'default'}
-          disabled={wallet.ethereum == undefined}
-          onClick={() => handleAddToMetamask(symbol)}
-        />
-      </AddToMetamask>
     </ProductPageSection>
   )
 }
@@ -61,7 +60,7 @@ const StyledTokenBalance = styled.div`
 
 const AddToMetamask = styled.div`
   display: inline-block;
-  float: left;
+  float: right;
 `
 
 export default ProductWalletBalance

--- a/src/hooks/useAddToMetamask.ts
+++ b/src/hooks/useAddToMetamask.ts
@@ -10,11 +10,12 @@ export const useAddToMetamask = () => {
     },
     CGI: {
       address: '0xada0a1202462085999652dc5310a7a9e2bf3ed42',
-      image: '',
+      image:
+        'https://set-core.s3.amazonaws.com/img/portfolios/coinshares_gold.png',
     },
     INDEX: {
       address: '0x0954906da0Bf32d5479e25f46056d22f08464cab',
-      image: '',
+      image: 'https://index-dao.s3.amazonaws.com/owl.png',
     },
   }
 

--- a/src/hooks/useAddToMetamask.ts
+++ b/src/hooks/useAddToMetamask.ts
@@ -1,0 +1,37 @@
+import useWallet from 'hooks/useWallet'
+
+export const useAddToMetamask = () => {
+  const wallet = useWallet()
+
+  const tokens: any = {
+    DPI: {
+      address: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
+      image: 'https://index-dao.s3.amazonaws.com/defi_pulse_index_set.svg',
+    },
+    CGI: {
+      address: '0xada0a1202462085999652dc5310a7a9e2bf3ed42',
+      image: '',
+    },
+    INDEX: {
+      address: '0x0954906da0Bf32d5479e25f46056d22f08464cab',
+      image: '',
+    },
+  }
+
+  const addToken = async (symbol: string) => {
+    await wallet.ethereum.request({
+      method: 'wallet_watchAsset',
+      params: {
+        type: 'ERC20',
+        options: {
+          address: tokens[symbol].address,
+          symbol: symbol,
+          decimals: 18,
+          image: tokens[symbol].image,
+        },
+      },
+    })
+  }
+
+  return addToken
+}


### PR DESCRIPTION
Add support for one-click adding tokens to metamask from the browser. I've attached an image of how it looks right now below, but if you can think of a better location/style for it, I'm happy to change it.
![Screenshot_20210310_002824](https://user-images.githubusercontent.com/16858330/110580923-94872000-8137-11eb-96cd-46bc180ff688.png)
