### PR TITLE
Added filter for proposals on vote page

### DIFF
--- a/src/views/Vote/Vote.tsx
+++ b/src/views/Vote/Vote.tsx
@@ -11,7 +11,7 @@ const Vote = (props: { title: string }) => {
 
   return (
     <Page>
-      <Container size='sm'>
+      <Container size='md'>
         <StyledPageHeader>Vote</StyledPageHeader>
         <Spacer size='sm' />
         <StyledPageSubheader>View and vote on proposals</StyledPageSubheader>

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -54,7 +54,7 @@ const ProposalTable: React.FC = () => {
                   .toUpperCase()
                   .includes(searchTerm.toUpperCase())
           
-          const passesFilter = proposalFilter || !searchTerm
+          const shouldDisplayProposal = proposalFilter || !searchTerm
 
           if (passesFilter) {
             return (

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -50,7 +50,7 @@ const ProposalTable: React.FC = () => {
           const isExecuted = indexProposals[id]?.msg?.payload?.end < currentTime
           
           const proposalFilter =
-                   indexProposals[id].msg.payload.name
+                   indexProposals[id].msg?.payload?.name?
                   .toUpperCase()
                   .includes(searchTerm.toUpperCase())
           

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -50,13 +50,11 @@ const ProposalTable: React.FC = () => {
           const isExecuted = indexProposals[id]?.msg?.payload?.end < currentTime
 
           if (
-            searchTerm &&
-            !indexProposals[id].msg.payload.name
+            !searchTerm ||
+            indexProposals[id].msg.payload.name
               .toUpperCase()
               .includes(searchTerm.toUpperCase())
           ) {
-            return
-          } else {
             return (
               <>
                 <StyledColumnRow>

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -48,13 +48,15 @@ const ProposalTable: React.FC = () => {
             indexProposals[id]?.msg?.payload?.start <= currentTime &&
             currentTime <= indexProposals[id]?.msg?.payload?.end
           const isExecuted = indexProposals[id]?.msg?.payload?.end < currentTime
+          
+          const proposalFilter =
+                   indexProposals[id].msg.payload.name
+                  .toUpperCase()
+                  .includes(searchTerm.toUpperCase())
+          
+          const passesFilter = proposalFilter || !searchTerm
 
-          if (
-            !searchTerm ||
-            indexProposals[id].msg.payload.name
-              .toUpperCase()
-              .includes(searchTerm.toUpperCase())
-          ) {
+          if (passesFilter) {
             return (
               <>
                 <StyledColumnRow>

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -56,7 +56,7 @@ const ProposalTable: React.FC = () => {
           
           const shouldDisplayProposal = proposalFilter || !searchTerm
 
-          if (passesFilter) {
+          if (shouldDisplayProposal) {
             return (
               <>
                 <StyledColumnRow>

--- a/src/views/Vote/components/ProposalTable.tsx
+++ b/src/views/Vote/components/ProposalTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Spacer } from 'react-neu'
 import useSnapshotProposals from 'hooks/useSnapshotProposals'
@@ -17,9 +17,15 @@ const ProposalTable: React.FC = () => {
   const { indexProposals = {} } = useSnapshotProposals()
   const currentTime = Math.round(new Date().getTime() / 1000)
   const proposalIds = Object.keys(indexProposals)
+  const [searchTerm, setSearchTerm] = useState('')
 
   return (
     <div>
+      <StyledInputField
+        type='text'
+        placeholder='Filter proposals'
+        onChange={(e) => setSearchTerm(e.target.value)}
+      />
       <StyledTable>
         <StyledBackground />
         <StyledProposalTableHeader>
@@ -43,46 +49,65 @@ const ProposalTable: React.FC = () => {
             currentTime <= indexProposals[id]?.msg?.payload?.end
           const isExecuted = indexProposals[id]?.msg?.payload?.end < currentTime
 
-          return (
-            <>
-              <StyledColumnRow>
-                <StyledColumn style={{ width: '60%' }}>
-                  {indexProposals[id].msg.payload.name}
-                </StyledColumn>
-                <StyledColumn style={{ width: '20%' }} isActive={isActive}>
-                  {isActive && 'Active'}
-                  {isExecuted && 'Executed'}
-                </StyledColumn>
-                <StyledColumn style={{ width: '20%' }}>
-                  <StyledButton
-                    onClick={() => {
-                      window.open(
-                        `${SNAPSHOT_INDEX_PROPOSAL_BASE}/${id}`,
-                        '_blank'
-                      )
-                    }}
-                    isActive={isActive}
-                  >
-                    View
-                  </StyledButton>
-                </StyledColumn>
-              </StyledColumnRow>
-              {i !== proposalIds.length - 1 ? (
-                <StyledDivider />
-              ) : (
-                <Spacer size='md' />
-              )}
-            </>
-          )
+          if (
+            searchTerm &&
+            !indexProposals[id].msg.payload.name
+              .toUpperCase()
+              .includes(searchTerm.toUpperCase())
+          ) {
+            return
+          } else {
+            return (
+              <>
+                <StyledColumnRow>
+                  <StyledColumn style={{ width: '60%' }}>
+                    {indexProposals[id].msg.payload.name}
+                  </StyledColumn>
+                  <StyledColumn style={{ width: '20%' }} isActive={isActive}>
+                    {isActive && 'Active'}
+                    {isExecuted && 'Executed'}
+                  </StyledColumn>
+                  <StyledColumn style={{ width: '20%' }}>
+                    <StyledButton
+                      onClick={() => {
+                        window.open(
+                          `${SNAPSHOT_INDEX_PROPOSAL_BASE}/${id}`,
+                          '_blank'
+                        )
+                      }}
+                      isActive={isActive}
+                    >
+                      View
+                    </StyledButton>
+                  </StyledColumn>
+                </StyledColumnRow>
+                {i !== proposalIds.length - 1 ? (
+                  <StyledDivider />
+                ) : (
+                  <Spacer size='md' />
+                )}
+              </>
+            )
+          }
         })}
       </StyledTable>
     </div>
   )
 }
 
+const StyledInputField = styled.input`
+  float: right;
+  position: relative;
+  bottom: 45px;
+  padding: 5px;
+  border-radius: 5px;
+  border: none;
+`
+
 const StyledEmptyMessage = styled.div`
   font-size: 18px;
   display: flex;
+  padding-bottom: 20px;
   justify-content: center;
   align-items: center;
 `


### PR DESCRIPTION
This PR adds a text field for filtering the proposal table on the vote page. If it is blank, no filter will be applied. 

<img width="803" alt="Screen Shot 2021-04-05 at 9 33 15 PM" src="https://user-images.githubusercontent.com/23125216/113646347-a97fa200-9656-11eb-94c5-a95667034316.png">
<img width="821" alt="Screen Shot 2021-04-05 at 9 33 50 PM" src="https://user-images.githubusercontent.com/23125216/113646354-ad132900-9656-11eb-95a0-629728083346.png">

Additional minor tweaks:
- Widened container for vote page
- Added bottom padding to no results message