### PR TITLE
Fix Price Chart Data

### DIFF
--- a/src/components/ProductPage/ProductPriceChanges.tsx
+++ b/src/components/ProductPage/ProductPriceChanges.tsx
@@ -21,8 +21,10 @@ const ProductPriceChanges: React.FC<ProductPriceChangesProps> = ({
   ]
 
   const calculatePriceChange = (daysOfComparison: number) => {
-    if (daysOfComparison == 1) {
-      const startPrice = hourlyPrices ? hourlyPrices.slice(-24)[0][1] : 1
+    if (daysOfComparison <= 30) {
+      const startPrice = hourlyPrices
+        ? hourlyPrices.slice(-24 * daysOfComparison)[0][1]
+        : 1
       const hourlyPricesLength = hourlyPrices ? hourlyPrices.length - 1 : 0
       const latestPrice = hourlyPrices ? hourlyPrices[hourlyPricesLength][1] : 1
       return ((latestPrice - startPrice) / startPrice) * 100

--- a/src/components/ProductPage/ProductPriceChanges.tsx
+++ b/src/components/ProductPage/ProductPriceChanges.tsx
@@ -6,17 +6,13 @@ import { ProductPageSection } from './ProductPageLayouts'
 
 interface ProductPriceChangesProps {
   prices?: number[][]
+  oneDayPrices?: number[][]
 }
 
 const ProductPriceChanges: React.FC<ProductPriceChangesProps> = ({
   prices,
+  oneDayPrices,
 }) => {
-  const [startTime] = prices?.[0] || [0]
-  const [latestTime, latestPrice] = prices?.[prices.length - 1] || [0, 0]
-  // Coingecko API returns each item as hourly data if < 90 days and daily data > 90 days
-  // So if time between start and end time < 90 days, 1 day of data is 24 array items.
-  const ninetyDays = 7776000000
-  const dataCadenceFor24Hours = latestTime - startTime < ninetyDays ? 24 : 1
   const priceChangeIntervals = [
     ['1 Day', 1],
     ['1 Month', 30],
@@ -25,14 +21,19 @@ const ProductPriceChanges: React.FC<ProductPriceChangesProps> = ({
   ]
 
   const calculatePriceChange = (daysOfComparison: number) => {
-    if (!prices || prices.length < daysOfComparison * dataCadenceFor24Hours) {
-      return 0
+    if (daysOfComparison == 1) {
+      const oneDayStartPrice = oneDayPrices ? oneDayPrices.slice(-24)[0][1] : 1
+      const oneDayPricesLength = oneDayPrices ? oneDayPrices.length - 1 : 0
+      const oneDayLatestPrice = oneDayPrices
+        ? oneDayPrices[oneDayPricesLength][1]
+        : 1
+      return ((oneDayLatestPrice - oneDayStartPrice) / oneDayStartPrice) * 100
+    } else if (prices && prices?.length > daysOfComparison) {
+      const startPrice = prices[prices.length - daysOfComparison][1]
+      const latestPrice = prices[prices.length - 1][1]
+      return ((latestPrice - startPrice) / startPrice) * 100
     }
-    const startPriceIndex =
-      prices.length - daysOfComparison * dataCadenceFor24Hours
-    const startPrice = prices[startPriceIndex][1]
-    const priceChange = ((latestPrice - startPrice) / startPrice) * 100
-    return priceChange
+    return 0
   }
 
   const renderAssetPriceChange = (priceChange: number) => {

--- a/src/components/ProductPage/ProductPriceChanges.tsx
+++ b/src/components/ProductPage/ProductPriceChanges.tsx
@@ -6,12 +6,12 @@ import { ProductPageSection } from './ProductPageLayouts'
 
 interface ProductPriceChangesProps {
   prices?: number[][]
-  oneDayPrices?: number[][]
+  hourlyPrices?: number[][]
 }
 
 const ProductPriceChanges: React.FC<ProductPriceChangesProps> = ({
   prices,
-  oneDayPrices,
+  hourlyPrices,
 }) => {
   const priceChangeIntervals = [
     ['1 Day', 1],
@@ -22,12 +22,10 @@ const ProductPriceChanges: React.FC<ProductPriceChangesProps> = ({
 
   const calculatePriceChange = (daysOfComparison: number) => {
     if (daysOfComparison == 1) {
-      const oneDayStartPrice = oneDayPrices ? oneDayPrices.slice(-24)[0][1] : 1
-      const oneDayPricesLength = oneDayPrices ? oneDayPrices.length - 1 : 0
-      const oneDayLatestPrice = oneDayPrices
-        ? oneDayPrices[oneDayPricesLength][1]
-        : 1
-      return ((oneDayLatestPrice - oneDayStartPrice) / oneDayStartPrice) * 100
+      const startPrice = hourlyPrices ? hourlyPrices.slice(-24)[0][1] : 1
+      const hourlyPricesLength = hourlyPrices ? hourlyPrices.length - 1 : 0
+      const latestPrice = hourlyPrices ? hourlyPrices[hourlyPricesLength][1] : 1
+      return ((latestPrice - startPrice) / startPrice) * 100
     } else if (prices && prices?.length > daysOfComparison) {
       const startPrice = prices[prices.length - daysOfComparison][1]
       const latestPrice = prices[prices.length - 1][1]

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -19,6 +19,10 @@ interface SimplePriceChartProps {
     x: string | number
     y: number
   }[]
+  dayData?: {
+    x: string | number
+    y: number
+  }[]
   onMouseMove?: (...args: any[]) => any
   onMouseLeave?: (...args: any[]) => any
   setIsDaily?: (...args: any[]) => any
@@ -29,6 +33,7 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   showTooltip,
   icon,
   data,
+  dayData,
   onMouseMove = () => {},
   onMouseLeave = () => {},
   setIsDaily = () => {},
@@ -56,11 +61,11 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   useEffect(() => {
     setTimeout(() => {
       if (durationSelector === 0) {
-        setPrice(data?.slice((data?.length * 29) / 30))
+        setPrice(dayData?.slice(-24))
       } else if (durationSelector === 1) {
-        setPrice(data?.slice((data?.length * 23) / 30))
+        setPrice(data?.slice(-7))
       } else if (durationSelector === 2) {
-        setPrice(data)
+        setPrice(data?.slice(-30))
       }
     }, 0)
   }, [durationSelector, data])

--- a/src/components/SimplePriceChart/SimplePriceChart.tsx
+++ b/src/components/SimplePriceChart/SimplePriceChart.tsx
@@ -19,7 +19,7 @@ interface SimplePriceChartProps {
     x: string | number
     y: number
   }[]
-  dayData?: {
+  hourlyData?: {
     x: string | number
     y: number
   }[]
@@ -33,7 +33,7 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
   showTooltip,
   icon,
   data,
-  dayData,
+  hourlyData,
   onMouseMove = () => {},
   onMouseLeave = () => {},
   setIsDaily = () => {},
@@ -60,12 +60,13 @@ const MarketDataChart: React.FC<SimplePriceChartProps> = ({
 
   useEffect(() => {
     setTimeout(() => {
+      const hourlyDataInterval = 24
       if (durationSelector === 0) {
-        setPrice(dayData?.slice(-24))
+        setPrice(hourlyData?.slice(-1 * hourlyDataInterval)) //last day, hourly
       } else if (durationSelector === 1) {
-        setPrice(data?.slice(-7))
+        setPrice(hourlyData?.slice(-7 * hourlyDataInterval)) //last 7 days, hourly
       } else if (durationSelector === 2) {
-        setPrice(data?.slice(-30))
+        setPrice(hourlyData?.slice(-30 * hourlyDataInterval)) //last 30 days, hourly
       }
     }, 0)
   }, [durationSelector, data])

--- a/src/contexts/CgiTokenMarketData/CgiTokenMarketDataContext.ts
+++ b/src/contexts/CgiTokenMarketData/CgiTokenMarketDataContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 interface CgiTokenMarketDataValues {
   prices?: number[][]
-  dayPrices?: number[][]
+  hourlyPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/CgiTokenMarketData/CgiTokenMarketDataContext.ts
+++ b/src/contexts/CgiTokenMarketData/CgiTokenMarketDataContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 interface CgiTokenMarketDataValues {
   prices?: number[][]
+  dayPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/CgiTokenMarketData/CgiTokenMarketDataProvider.tsx
+++ b/src/contexts/CgiTokenMarketData/CgiTokenMarketDataProvider.tsx
@@ -10,7 +10,7 @@ const CgiMarketDataProvider: React.FC = ({ children }) => {
     const endTime = Date.now() / 1000
     const startTime = endTime - 86400 * 30 // 30 days
 
-    fetchHistoricalTokenMarketData(coingeckoCgiId, startTime, endTime)
+    fetchHistoricalTokenMarketData(coingeckoCgiId)
       .then((response: any) => {
         setCgiMarketData(response)
       })

--- a/src/contexts/CgiTokenMarketData/CgiTokenMarketDataProvider.tsx
+++ b/src/contexts/CgiTokenMarketData/CgiTokenMarketDataProvider.tsx
@@ -7,9 +7,6 @@ const CgiMarketDataProvider: React.FC = ({ children }) => {
   const [cgiMarketData, setCgiMarketData] = useState<any>({})
 
   useEffect(() => {
-    const endTime = Date.now() / 1000
-    const startTime = endTime - 86400 * 30 // 30 days
-
     fetchHistoricalTokenMarketData(coingeckoCgiId)
       .then((response: any) => {
         setCgiMarketData(response)

--- a/src/contexts/DpiTokenMarketData/DpiTokenMarketDataContext.ts
+++ b/src/contexts/DpiTokenMarketData/DpiTokenMarketDataContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 interface DpiTokenMarketDataValues {
   prices?: number[][]
+  dayPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/DpiTokenMarketData/DpiTokenMarketDataContext.ts
+++ b/src/contexts/DpiTokenMarketData/DpiTokenMarketDataContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 interface DpiTokenMarketDataValues {
   prices?: number[][]
-  dayPrices?: number[][]
+  hourlyPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/DpiTokenMarketData/DpiTokenMarketDataProvider.tsx
+++ b/src/contexts/DpiTokenMarketData/DpiTokenMarketDataProvider.tsx
@@ -10,7 +10,7 @@ const DpiMarketDataProvider: React.FC = ({ children }) => {
     const endTime = Date.now() / 1000
     const startTime = endTime - 86400 * 30 // 30 days
 
-    fetchHistoricalTokenMarketData(coingeckoDpiId, startTime, endTime)
+    fetchHistoricalTokenMarketData(coingeckoDpiId)
       .then((response: any) => {
         setDpiMarketData(response)
       })

--- a/src/contexts/DpiTokenMarketData/DpiTokenMarketDataProvider.tsx
+++ b/src/contexts/DpiTokenMarketData/DpiTokenMarketDataProvider.tsx
@@ -7,9 +7,6 @@ const DpiMarketDataProvider: React.FC = ({ children }) => {
   const [dpiMarketData, setDpiMarketData] = useState<any>({})
 
   useEffect(() => {
-    const endTime = Date.now() / 1000
-    const startTime = endTime - 86400 * 30 // 30 days
-
     fetchHistoricalTokenMarketData(coingeckoDpiId)
       .then((response: any) => {
         setDpiMarketData(response)

--- a/src/contexts/FliTokenMarketData/FliTokenMarketDataContext.ts
+++ b/src/contexts/FliTokenMarketData/FliTokenMarketDataContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 interface FliTokenMarketDataValues {
   prices?: number[][]
+  dayPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/FliTokenMarketData/FliTokenMarketDataContext.ts
+++ b/src/contexts/FliTokenMarketData/FliTokenMarketDataContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 interface FliTokenMarketDataValues {
   prices?: number[][]
-  dayPrices?: number[][]
+  hourlyPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/FliTokenMarketData/FliTokenMarketDataProvider.tsx
+++ b/src/contexts/FliTokenMarketData/FliTokenMarketDataProvider.tsx
@@ -7,9 +7,6 @@ const FliMarketDataProvider: React.FC = ({ children }) => {
   const [fliMarketData, setFliMarketData] = useState<any>({})
 
   useEffect(() => {
-    const endTime = Date.now() / 1000
-    const startTime = endTime - 86400 * 30 // 30 days
-
     fetchHistoricalTokenMarketData(coingeckoFliId)
       .then((response: any) => {
         setFliMarketData(response)

--- a/src/contexts/FliTokenMarketData/FliTokenMarketDataProvider.tsx
+++ b/src/contexts/FliTokenMarketData/FliTokenMarketDataProvider.tsx
@@ -10,7 +10,7 @@ const FliMarketDataProvider: React.FC = ({ children }) => {
     const endTime = Date.now() / 1000
     const startTime = endTime - 86400 * 30 // 30 days
 
-    fetchHistoricalTokenMarketData(coingeckoFliId, startTime, endTime)
+    fetchHistoricalTokenMarketData(coingeckoFliId)
       .then((response: any) => {
         setFliMarketData(response)
       })

--- a/src/contexts/IndexTokenMarketData/IndexTokenMarketDataContext.ts
+++ b/src/contexts/IndexTokenMarketData/IndexTokenMarketDataContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 interface IndexTokenMarketDataValues {
   prices?: number[][]
-  dayPrices?: number[][]
+  hourlyPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/IndexTokenMarketData/IndexTokenMarketDataContext.ts
+++ b/src/contexts/IndexTokenMarketData/IndexTokenMarketDataContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 interface IndexTokenMarketDataValues {
   prices?: number[][]
+  dayPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
+++ b/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
@@ -7,9 +7,6 @@ const IndexMarketDataProvider: React.FC = ({ children }) => {
   const [indexMarketData, setIndexMarketData] = useState<any>({})
 
   useEffect(() => {
-    const endTime = Date.now() / 1000
-    const startTime = endTime - 86400 * 30 // 30 days
-
     fetchHistoricalTokenMarketData(coingeckoIndexId)
       .then((response: any) => {
         setIndexMarketData(response)

--- a/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
+++ b/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
@@ -10,7 +10,7 @@ const IndexMarketDataProvider: React.FC = ({ children }) => {
     const endTime = Date.now() / 1000
     const startTime = endTime - 86400 * 30 // 30 days
 
-    fetchHistoricalTokenMarketData(coingeckoIndexId, startTime, endTime)
+    fetchHistoricalTokenMarketData(coingeckoIndexId)
       .then((response: any) => {
         setIndexMarketData(response)
       })

--- a/src/contexts/MviTokenMarketData/MviTokenMarketDataContext.ts
+++ b/src/contexts/MviTokenMarketData/MviTokenMarketDataContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 interface MviTokenMarketDataValues {
   prices?: number[][]
-  dayPrices?: number[][]
+  hourlyPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/MviTokenMarketData/MviTokenMarketDataContext.ts
+++ b/src/contexts/MviTokenMarketData/MviTokenMarketDataContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 interface MviTokenMarketDataValues {
   prices?: number[][]
+  dayPrices?: number[][]
   marketcaps?: number[][]
   volumes?: number[][]
   latestPrice?: number

--- a/src/contexts/MviTokenMarketData/MviTokenMarketDataProvider.tsx
+++ b/src/contexts/MviTokenMarketData/MviTokenMarketDataProvider.tsx
@@ -10,7 +10,7 @@ const MviMarketDataProvider: React.FC = ({ children }) => {
     const endTime = Date.now() / 1000
     const startTime = endTime - 86400 * 30 // 30 days
 
-    fetchHistoricalTokenMarketData(coingeckoMviId, startTime, endTime)
+    fetchHistoricalTokenMarketData(coingeckoMviId)
       .then((response: any) => {
         setMviMarketData(response)
       })

--- a/src/contexts/MviTokenMarketData/MviTokenMarketDataProvider.tsx
+++ b/src/contexts/MviTokenMarketData/MviTokenMarketDataProvider.tsx
@@ -7,9 +7,6 @@ const MviMarketDataProvider: React.FC = ({ children }) => {
   const [mviMarketData, setMviMarketData] = useState<any>({})
 
   useEffect(() => {
-    const endTime = Date.now() / 1000
-    const startTime = endTime - 86400 * 30 // 30 days
-
     fetchHistoricalTokenMarketData(coingeckoMviId)
       .then((response: any) => {
         setMviMarketData(response)

--- a/src/utils/coingeckoApi.ts
+++ b/src/utils/coingeckoApi.ts
@@ -7,23 +7,23 @@ export const fetchHistoricalTokenMarketData = (
   const coingeckoMaxTokenDataUrl =
     baseURL +
     `/coins/${id}/market_chart?vs_currency=${baseCurrency}&days=max&interval=daily`
-  const coingeckoTwoDayTokenDataUrl =
-    baseURL + `/coins/${id}/market_chart?vs_currency=${baseCurrency}&days=2`
+  const coingeckoHourlyTokenDataUrl =
+    baseURL + `/coins/${id}/market_chart?vs_currency=${baseCurrency}&days=30`
 
   return Promise.all([
     fetch(coingeckoMaxTokenDataUrl),
-    fetch(coingeckoTwoDayTokenDataUrl),
+    fetch(coingeckoHourlyTokenDataUrl),
   ])
     .then((responses) =>
       Promise.all(responses.map((response) => response.json()))
     )
     .then((data) => {
       const prices = data[0].prices,
-        dayPrices = data[1].prices,
+        hourlyPrices = data[1].prices,
         marketcaps = data[0].market_caps,
         volumes = data[0].total_volumes
 
-      return { prices, dayPrices, marketcaps, volumes }
+      return { prices, hourlyPrices, marketcaps, volumes }
     })
     .catch((error) => console.log(error))
 }

--- a/src/views/CGI/CGI.tsx
+++ b/src/views/CGI/CGI.tsx
@@ -23,7 +23,7 @@ const CgiProductPage = (props: { title: string }) => {
     document.title = props.title
   }, [props.title])
 
-  const { prices, latestPrice } = useCgiTokenMarketData()
+  const { prices, dayPrices, latestPrice } = useCgiTokenMarketData()
   const { components } = useCgiIndexComponents()
   const { cgiBalance } = useBalances()
 
@@ -40,7 +40,7 @@ const CgiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={cgiBalance}
           />
-          <PriceChanges prices={prices} />
+          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
           <IndexComponentsTable components={components} />
           {/* <TokenStats
             latestPrice={latestPrice}

--- a/src/views/CGI/CGI.tsx
+++ b/src/views/CGI/CGI.tsx
@@ -23,7 +23,7 @@ const CgiProductPage = (props: { title: string }) => {
     document.title = props.title
   }, [props.title])
 
-  const { prices, dayPrices, latestPrice } = useCgiTokenMarketData()
+  const { prices, hourlyPrices, latestPrice } = useCgiTokenMarketData()
   const { components } = useCgiIndexComponents()
   const { cgiBalance } = useBalances()
 
@@ -40,7 +40,7 @@ const CgiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={cgiBalance}
           />
-          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
+          <PriceChanges prices={prices} hourlyPrices={hourlyPrices} />
           <IndexComponentsTable components={components} />
           {/* <TokenStats
             latestPrice={latestPrice}

--- a/src/views/CGI/components/MarketData.tsx
+++ b/src/views/CGI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useCgiTokenMarketData from 'hooks/useCgiTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices, dayPrices } = useCgiTokenMarketData()
+  const { latestPrice, prices, hourlyPrices } = useCgiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,7 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={cgiTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
-        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
+        hourlyData={hourlyPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/CGI/components/MarketData.tsx
+++ b/src/views/CGI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useCgiTokenMarketData from 'hooks/useCgiTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices } = useCgiTokenMarketData()
+  const { latestPrice, prices, dayPrices } = useCgiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,6 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={cgiTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
+        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/DPI/DPI.tsx
+++ b/src/views/DPI/DPI.tsx
@@ -33,6 +33,7 @@ const DpiProductPage = (props: { title: string }) => {
 
   const {
     prices,
+    dayPrices,
     latestPrice,
     latestMarketCap,
     latestVolume,
@@ -65,7 +66,7 @@ const DpiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={dpiBalance}
           />
-          <PriceChanges prices={prices} />
+          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
           <IndexComponentsTable components={components} />
           <TokenStats
             latestPrice={latestPrice}

--- a/src/views/DPI/DPI.tsx
+++ b/src/views/DPI/DPI.tsx
@@ -35,7 +35,7 @@ const DpiProductPage = (props: { title: string }) => {
 
   const {
     prices,
-    dayPrices,
+    hourlyPrices,
     latestPrice,
     latestMarketCap,
     latestVolume,
@@ -70,7 +70,7 @@ const DpiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={dpiBalance}
           />
-          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
+          <PriceChanges prices={prices} hourlyPrices={hourlyPrices} />
           <IndexComponentsTable components={components} />
           <TokenStats
             latestPrice={latestPrice}

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices, dayPrices } = useDpiTokenMarketData()
+  const { latestPrice, prices, hourlyPrices } = useDpiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,7 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={dpiTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
-        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
+        hourlyData={hourlyPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/DPI/components/MarketData.tsx
+++ b/src/views/DPI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useDpiTokenMarketData from 'hooks/useDpiTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices } = useDpiTokenMarketData()
+  const { latestPrice, prices, dayPrices } = useDpiTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,6 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={dpiTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
+        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/FLI/FLI.tsx
+++ b/src/views/FLI/FLI.tsx
@@ -23,7 +23,7 @@ const FliProductPage = (props: { title: string }) => {
     document.title = props.title
   }, [])
 
-  const { prices, latestPrice } = useFliTokenMarketData()
+  const { prices, dayPrices, latestPrice } = useFliTokenMarketData()
   const { components, symbol } = useFliIndexPortfolioData()
   const { fliBalance } = useBalances()
 
@@ -42,7 +42,7 @@ const FliProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={fliBalance}
           />
-          <PriceChanges prices={prices} />
+          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
           <IndexComponentsTable components={components} />
           <Description>
             <strong>The Ethereum Flexible Leverage Index</strong> lets you

--- a/src/views/FLI/FLI.tsx
+++ b/src/views/FLI/FLI.tsx
@@ -23,7 +23,7 @@ const FliProductPage = (props: { title: string }) => {
     document.title = props.title
   }, [])
 
-  const { prices, dayPrices, latestPrice } = useFliTokenMarketData()
+  const { prices, hourlyPrices, latestPrice } = useFliTokenMarketData()
   const { components, symbol } = useFliIndexPortfolioData()
   const { fliBalance } = useBalances()
 
@@ -42,7 +42,7 @@ const FliProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={fliBalance}
           />
-          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
+          <PriceChanges prices={prices} hourlyPrices={hourlyPrices} />
           <IndexComponentsTable components={components} />
           <Description>
             <strong>The Ethereum Flexible Leverage Index</strong> lets you

--- a/src/views/FLI/components/MarketData.tsx
+++ b/src/views/FLI/components/MarketData.tsx
@@ -8,7 +8,7 @@ import useFliTokenMarketData from 'hooks/useFliTokenMarketData'
 import useFliIndexPortfolioData from 'hooks/useFliIndexPortfolioData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices, dayPrices } = useFliTokenMarketData()
+  const { latestPrice, prices, hourlyPrices } = useFliTokenMarketData()
   const { symbol, name, image } = useFliIndexPortfolioData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
@@ -87,7 +87,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={fliTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
-        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
+        hourlyData={hourlyPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/FLI/components/MarketData.tsx
+++ b/src/views/FLI/components/MarketData.tsx
@@ -8,7 +8,7 @@ import useFliTokenMarketData from 'hooks/useFliTokenMarketData'
 import useFliIndexPortfolioData from 'hooks/useFliIndexPortfolioData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices } = useFliTokenMarketData()
+  const { latestPrice, prices, dayPrices } = useFliTokenMarketData()
   const { symbol, name, image } = useFliIndexPortfolioData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
@@ -87,6 +87,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={fliTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
+        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/INDEX/INDEXPage.tsx
+++ b/src/views/INDEX/INDEXPage.tsx
@@ -26,6 +26,7 @@ const DpiProductPage = (props: { title: string }) => {
 
   const {
     prices,
+    dayPrices,
     latestPrice,
     latestMarketCap,
     latestVolume,
@@ -45,7 +46,7 @@ const DpiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={indexBalance}
           />
-          <PriceChanges prices={prices} />
+          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
           <TokenStats
             latestPrice={latestPrice}
             latestVolume={latestVolume}

--- a/src/views/INDEX/INDEXPage.tsx
+++ b/src/views/INDEX/INDEXPage.tsx
@@ -26,7 +26,7 @@ const DpiProductPage = (props: { title: string }) => {
 
   const {
     prices,
-    dayPrices,
+    hourlyPrices,
     latestPrice,
     latestMarketCap,
     latestVolume,
@@ -46,7 +46,7 @@ const DpiProductPage = (props: { title: string }) => {
             latestPrice={latestPrice}
             currentBalance={indexBalance}
           />
-          <PriceChanges prices={prices} oneDayPrices={dayPrices} />
+          <PriceChanges prices={prices} hourlyPrices={hourlyPrices} />
           <TokenStats
             latestPrice={latestPrice}
             latestVolume={latestVolume}

--- a/src/views/INDEX/components/MarketData.tsx
+++ b/src/views/INDEX/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useIndexTokenMarketData from 'hooks/useIndexTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices, dayPrices } = useIndexTokenMarketData()
+  const { latestPrice, prices, hourlyPrices } = useIndexTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -79,7 +79,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={IndexToken}
         data={prices?.map(([x, y]) => ({ x, y }))}
-        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
+        hourlyData={hourlyPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/INDEX/components/MarketData.tsx
+++ b/src/views/INDEX/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useIndexTokenMarketData from 'hooks/useIndexTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices } = useIndexTokenMarketData()
+  const { latestPrice, prices, dayPrices } = useIndexTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -79,6 +79,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={IndexToken}
         data={prices?.map(([x, y]) => ({ x, y }))}
+        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/MVI/components/MarketData.tsx
+++ b/src/views/MVI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useMviTokenMarketData from 'hooks/useMviTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices, dayPrices } = useMviTokenMarketData()
+  const { latestPrice, prices, hourlyPrices } = useMviTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,7 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={mviTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
-        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
+        hourlyData={hourlyPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}

--- a/src/views/MVI/components/MarketData.tsx
+++ b/src/views/MVI/components/MarketData.tsx
@@ -7,7 +7,7 @@ import SimplePriceChart from 'components/SimplePriceChart'
 import useMviTokenMarketData from 'hooks/useMviTokenMarketData'
 
 const MarketData: React.FC = () => {
-  const { latestPrice, prices } = useMviTokenMarketData()
+  const { latestPrice, prices, dayPrices } = useMviTokenMarketData()
   const [chartPrice, setChartPrice] = useState<number>(0)
   const [chartDate, setChartDate] = useState<number>(Date.now())
   const [isDaily, setIsDaily] = useState<Boolean>(false)
@@ -85,6 +85,7 @@ const MarketData: React.FC = () => {
       <SimplePriceChart
         icon={mviTokenIcon}
         data={prices?.map(([x, y]) => ({ x, y }))}
+        dayData={dayPrices?.map(([x, y]) => ({ x, y }))}
         onMouseMove={updateChartPrice}
         onMouseLeave={resetChartPrice}
         setIsDaily={setIsDaily}


### PR DESCRIPTION
- Data from CoinGecko now being pulled in 2 ways, once for the last 2 days in hourly interval, once in daily interval for max days available
- This should allow us to be more future ready for when a product goes beyond 30 days of age
- DPI data now actually getting full range of data, whereas before it was capped at 30 days, breaking the price charts
- These changes make it trivial to add more windows of time for the chart (3M, 1Y, etc) should we ever decide to do so

DPI 'Changes' section now has proper data to feed off of
![image](https://user-images.githubusercontent.com/7647623/114784745-acab1a00-9d49-11eb-901f-6bb62eb48f28.png)
