### PR TITLE
[Bugfix] Remove Approvals when Switching Accounts

### DIFF
--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -37,7 +37,7 @@ const useApproval = (
       setIsApproved(result)
       setIsApproving(false)
     } catch (e) {
-      setIsApproved(false)
+      setIsApproving(false)
       return false
     }
   }, [

--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -37,7 +37,7 @@ const useApproval = (
       setIsApproved(result)
       setIsApproving(false)
     } catch (e) {
-      setIsApproving(false)
+      setIsApproved(false)
       return false
     }
   }, [
@@ -53,7 +53,10 @@ const useApproval = (
   useEffect(() => {
     if (!!allowance?.toNumber()) {
       setIsApproved(true)
+      return
     }
+
+    setIsApproved(false)
   }, [allowance, setIsApproved])
 
   return {


### PR DESCRIPTION
* When logging into a new account, approvals will be reset if falsey.