### PR TITLE
[Bugfix] Clicking on backdrop was not closing the WalletModal

### DIFF
--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -85,7 +85,7 @@ const WalletModal: React.FC<ModalProps> = ({ isOpen, onDismiss }) => {
   )
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} onDismiss={onDismiss}>
       <StyledModalBody>
         <ModalTitle text='My Wallet' />
         <ModalContent>


### PR DESCRIPTION
The onDismiss function was not being passed as prop to the CustomModal component.