### PR TITLE
Update index market data to be optional to avoid potential crashes

### DIFF
--- a/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
+++ b/src/contexts/IndexTokenMarketData/IndexTokenMarketDataProvider.tsx
@@ -22,8 +22,8 @@ const IndexMarketDataProvider: React.FC = ({ children }) => {
       value={{
         ...indexMarketData,
         latestMarketCap: selectLatestMarketData(indexMarketData?.marketcaps),
-        latestPrice: selectLatestMarketData(indexMarketData.hourlyPrices),
-        latestVolume: selectLatestMarketData(indexMarketData.volumes),
+        latestPrice: selectLatestMarketData(indexMarketData?.hourlyPrices),
+        latestVolume: selectLatestMarketData(indexMarketData?.volumes),
       }}
     >
       {children}


### PR DESCRIPTION
## **Type of Change**

###### *Select a category that relates to the content of your pull request (choose all that apply).*

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

While working on another task I had a _crash_  with the index market data. So this is a small fix to avoid potential crashes when index market data is `null`. Probably a rare case but the `marketcaps` line was already handled correctly defining an optional, so I guess it won't hurt to update the other two lines as well (to be safe).

&nbsp;

### **Fixes: Issue #**

&nbsp;

## **Test Data or Screenshots**

<img width="735" alt="test-pass" src="https://user-images.githubusercontent.com/2104965/128228449-5ff7bb46-215e-46dc-88a4-c5720864d123.png">

&nbsp;

## **Submission Reminders**

###### *By submitting this pull request, you are confirming the following to be true:*

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
