### PR TITLE
Hide supply cap if not provided

### DIFF
--- a/src/components/ProductPage/ProductTokenStats.tsx
+++ b/src/components/ProductPage/ProductTokenStats.tsx
@@ -12,6 +12,10 @@ interface ProductTokenStatsProps {
     streamingFee: string
   }
   netAssetValue: number
+  /**
+   * The total supply cap of this product. If no supply cap is provided, supply
+   * cap is not displayed.
+   */
   supplyCap: BigNumber | undefined
   currentSupply: BigNumber | undefined
 }
@@ -36,7 +40,7 @@ const ProductTokenStats: React.FC<ProductTokenStatsProps> = ({
     </StyledStat>
   )
 
-  const supplyCapStat = (
+  const supplyCapStat = supplyCap && (
     <StyledStat>
       <StyledStatTitle>Supply Cap</StyledStatTitle>
       <StyledStatMetric>{formattedSupplyCap()}</StyledStatMetric>


### PR DESCRIPTION
Fixes (part of) https://github.com/SetProtocol/index-ui/issues/330

This change hides the supply cap for assets that don't have a supply cap (i.e. BED)

Before | After
--- | ---
<img width="827" alt="Screen Shot 2021-08-09 at 4 47 04 PM" src="https://user-images.githubusercontent.com/3699047/128772645-00ae087f-93ef-4880-8141-9362eedcfb0c.png"> | <img width="840" alt="Screen Shot 2021-08-09 at 4 46 57 PM" src="https://user-images.githubusercontent.com/3699047/128772650-8325cbbe-b26b-4de8-89c5-8112b087925d.png">

Tagging @0xModene 
