### PR TITLE
Improve market cap

### DIFF
--- a/src/components/ProductPage/ProductTokenStats.tsx
+++ b/src/components/ProductPage/ProductTokenStats.tsx
@@ -22,12 +22,24 @@ const ProductTokenStats: React.FC<ProductTokenStatsProps> = ({
   fees,
   supplyCap,
   currentSupply,
+  netAssetValue,
 }) => {
   const formatMetric = (metricValue: number) =>
     numeral(metricValue).format('0.00a').toString().toUpperCase()
 
   const formattedSupplyCap = () =>
     supplyCap ? numeral(supplyCap?.toString() || '0').format('0,0') : '--'
+
+  const formattedMarketCap = () => {
+    if (latestMarketCap) {
+      return "$" + formatMetric(latestMarketCap)
+    } else if (currentSupply) {
+      const approxMarketCap = Number(currentSupply) * netAssetValue
+      return "$" + formatMetric(approxMarketCap)
+    } else {
+      return '--'
+    }
+  }
 
   const streamingFee = fees?.streamingFee && (
     <StyledStat>
@@ -53,7 +65,7 @@ const ProductTokenStats: React.FC<ProductTokenStatsProps> = ({
         <StyledStat>
           <StyledStatTitle>Market Cap</StyledStatTitle>
           <StyledStatMetric>
-            ${formatMetric(latestMarketCap || 0)}
+            {formattedMarketCap()}
           </StyledStatMetric>
         </StyledStat>
         <StyledStat>

--- a/src/contexts/Balances/Provider.tsx
+++ b/src/contexts/Balances/Provider.tsx
@@ -184,7 +184,6 @@ const Provider: React.FC = ({ children }) => {
 
   const fetchTotalSupplies = useCallback(
     async (provider: provider) => {
-      console.info("invoked fetchTotalSupplies")
       const totalSupplies = await Promise.all([
         getTotalSupply(provider, eth2xfliTokenAddress as string),
         getTotalSupply(provider, btc2xfliTokenAddress as string),
@@ -193,7 +192,6 @@ const Provider: React.FC = ({ children }) => {
         getTotalSupply(provider, bedTokenAddress as string),
       ])
 
-      console.info(`DPI totaly supply ${new BigNumber(totalSupplies[2]).dividedBy(new BigNumber(10).pow(18))}`)
       setEthFliTotalSupply(
         new BigNumber(totalSupplies[0]).dividedBy(new BigNumber(10).pow(18))
       )
@@ -244,7 +242,6 @@ const Provider: React.FC = ({ children }) => {
   useEffect(() => {
     if (account && ethereum) {
       fetchBalances(account, ethereum)
-      console.log("invoking fetchTotalSupplies")
       fetchTotalSupplies(ethereum)
       let refreshInterval = setInterval(
         () => fetchBalances(account, ethereum),

--- a/src/contexts/Balances/Provider.tsx
+++ b/src/contexts/Balances/Provider.tsx
@@ -184,6 +184,7 @@ const Provider: React.FC = ({ children }) => {
 
   const fetchTotalSupplies = useCallback(
     async (provider: provider) => {
+      console.info("invoked fetchTotalSupplies")
       const totalSupplies = await Promise.all([
         getTotalSupply(provider, eth2xfliTokenAddress as string),
         getTotalSupply(provider, btc2xfliTokenAddress as string),
@@ -192,6 +193,7 @@ const Provider: React.FC = ({ children }) => {
         getTotalSupply(provider, bedTokenAddress as string),
       ])
 
+      console.info(`DPI totaly supply ${new BigNumber(totalSupplies[2]).dividedBy(new BigNumber(10).pow(18))}`)
       setEthFliTotalSupply(
         new BigNumber(totalSupplies[0]).dividedBy(new BigNumber(10).pow(18))
       )
@@ -242,6 +244,7 @@ const Provider: React.FC = ({ children }) => {
   useEffect(() => {
     if (account && ethereum) {
       fetchBalances(account, ethereum)
+      console.log("invoking fetchTotalSupplies")
       fetchTotalSupplies(ethereum)
       let refreshInterval = setInterval(
         () => fetchBalances(account, ethereum),


### PR DESCRIPTION
Fixes #330

If a market cap is provided, display it.
If total supply is provided, approximate market cap as supply * price. This may be useful for future product launches where CoinGecko doesn't provide market cap on day 1.
If market cap and supply aren't provided, display "--"

## Screenshots for DPI

Scenario | Screenshot
--- | ---
If market cap is provided | <img width="825" alt="Screen Shot 2021-08-09 at 6 10 05 PM" src="https://user-images.githubusercontent.com/3699047/128781311-eedfd18c-c389-4008-9ad4-9121a1e116eb.png">
If total supply is provided | <img width="825" alt="Screen Shot 2021-08-09 at 6 09 42 PM" src="https://user-images.githubusercontent.com/3699047/128781360-e9d9a99b-5d91-4673-b6a8-4582493ff47e.png">
Neither are provided | <img width="829" alt="Screen Shot 2021-08-09 at 6 09 22 PM" src="https://user-images.githubusercontent.com/3699047/128781393-81d5f6db-a01b-44f6-acd0-9d495c190f8b.png">


Tagging @0xModene 

