### PR TITLE
Relayout nav links

### DIFF
--- a/src/components/TopBar/components/GovernanceDropdown.tsx
+++ b/src/components/TopBar/components/GovernanceDropdown.tsx
@@ -32,16 +32,14 @@ const GovernanceDropdown: React.FC = () => {
 
   const dropdownSelectStyles = useMemo(() => {
     const isResourcesRouteActive =
-      pathname === '/about' ||
-      pathname === '/news' ||
-      pathname === '/rewards' ||
-      pathname === '/how-to-buy' ||
-      pathname === '/vote'
+      pathname === '/index' ||
+      pathname === '/vote' ||
+      pathname === '/rewards'
 
     return {
       control: (styles: any) => ({
         ...styles,
-        width: 130,
+        width: 140,
         background: 'none',
         border: 'none',
       }),
@@ -60,6 +58,7 @@ const GovernanceDropdown: React.FC = () => {
       }),
       menu: (styles: any) => ({
         ...styles,
+        width: 200,
         color: 'black',
       }),
       dropdownIndicator: (styles: any) => ({
@@ -86,38 +85,26 @@ const GovernanceDropdown: React.FC = () => {
   return (
     <Select
       isSearchable={false}
-      value={{ label: 'Resources' } as any}
+      value={{ label: 'Governance' }}
       options={[
         {
-          value: 'about',
-          label: 'About',
+          value: 'index',
+          label: 'Index Coop Token',
         },
         {
-          value: 'news',
-          label: 'News',
+          value: 'vote',
+          label: 'Vote',
+          link: 'https://snapshot.org/#/index-coop.eth'
         },
         {
-          value: 'docs',
-          label: 'Docs',
+          value: 'handbook',
+          label: 'Handbook',
           link: 'https://docs.indexcoop.com/',
         },
         {
           value: 'rewards',
           label: 'Rewards',
-        },
-        {
-          value: 'vote',
-          label: 'Vote',
-        },
-        {
-          value: 'how-to-buy',
-          label: 'How to Buy',
-        },
-        {
-          value: 'institutions',
-          label: 'Institutions',
-          link: 'https://institutions.indexcoop.com/',
-        },
+        }
       ]}
       components={{
         Option: CustomOption,
@@ -128,8 +115,9 @@ const GovernanceDropdown: React.FC = () => {
 }
 
 const CustomDropdownOption = styled.div`
-  width: 120px;
+  width: 190px;
   margin: 10px;
+  overflow: hidden;
 `
 
 const StyledLink = styled(NavLink)`

--- a/src/components/TopBar/components/GovernanceDropdown.tsx
+++ b/src/components/TopBar/components/GovernanceDropdown.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { NavLink, useLocation } from 'react-router-dom'
+import Select from 'react-select'
+import { useTheme } from 'react-neu'
+
+const CustomOption = (props: any) => {
+  const { innerProps, value, label, data } = props
+
+  if (data?.link) {
+    return (
+      <CustomDropdownOption {...innerProps}>
+        <StyledOutboundLink href={data.link} target='_blank'>
+          {label}
+        </StyledOutboundLink>
+      </CustomDropdownOption>
+    )
+  }
+
+  return (
+    <CustomDropdownOption {...innerProps}>
+      <StyledLink exact activeClassName='active' to={`/${value}`}>
+        {label}
+      </StyledLink>
+    </CustomDropdownOption>
+  )
+}
+
+const GovernanceDropdown: React.FC = () => {
+  const theme = useTheme()
+  const { pathname } = useLocation()
+
+  const dropdownSelectStyles = useMemo(() => {
+    const isResourcesRouteActive =
+      pathname === '/about' ||
+      pathname === '/news' ||
+      pathname === '/rewards' ||
+      pathname === '/how-to-buy' ||
+      pathname === '/vote'
+
+    return {
+      control: (styles: any) => ({
+        ...styles,
+        width: 130,
+        background: 'none',
+        border: 'none',
+      }),
+      singleValue: (styles: any) => ({
+        ...styles,
+        'color': isResourcesRouteActive
+          ? theme.colors.primary.light
+          : theme.colors.grey[500],
+        'fontWeight': 600,
+        'cursor': 'pointer',
+        '&:hover': {
+          color: isResourcesRouteActive
+            ? theme.colors.primary.light
+            : theme.colors.grey[600],
+        },
+      }),
+      menu: (styles: any) => ({
+        ...styles,
+        color: 'black',
+      }),
+      dropdownIndicator: (styles: any) => ({
+        ...styles,
+        'color': isResourcesRouteActive
+          ? theme.colors.primary.light
+          : theme.colors.grey[500],
+        'cursor': 'pointer',
+        '&:hover': {
+          color: isResourcesRouteActive
+            ? theme.colors.primary.light
+            : theme.colors.grey[500],
+        },
+      }),
+      indicatorSeparator: () => ({}),
+      indicatorContainer: (styles: any) => ({
+        ...styles,
+        marginLeft: 0,
+        padding: 0,
+      }),
+    }
+  }, [theme, pathname])
+
+  return (
+    <Select
+      isSearchable={false}
+      value={{ label: 'Resources' } as any}
+      options={[
+        {
+          value: 'about',
+          label: 'About',
+        },
+        {
+          value: 'news',
+          label: 'News',
+        },
+        {
+          value: 'docs',
+          label: 'Docs',
+          link: 'https://docs.indexcoop.com/',
+        },
+        {
+          value: 'rewards',
+          label: 'Rewards',
+        },
+        {
+          value: 'vote',
+          label: 'Vote',
+        },
+        {
+          value: 'how-to-buy',
+          label: 'How to Buy',
+        },
+        {
+          value: 'institutions',
+          label: 'Institutions',
+          link: 'https://institutions.indexcoop.com/',
+        },
+      ]}
+      components={{
+        Option: CustomOption,
+      }}
+      styles={dropdownSelectStyles}
+    />
+  )
+}
+
+const CustomDropdownOption = styled.div`
+  width: 120px;
+  margin: 10px;
+`
+
+const StyledLink = styled(NavLink)`
+  color: ${(props) => props.theme.colors.grey[500]};
+  font-weight: 700;
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
+  text-decoration: none;
+  &:hover {
+    color: ${(props) => props.theme.colors.grey[600]};
+  }
+  &.active {
+    color: ${(props) => props.theme.colors.primary.light};
+  }
+`
+
+const StyledOutboundLink = styled.a`
+  color: ${(props) => props.theme.colors.grey[500]};
+  font-weight: 700;
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
+  text-decoration: none;
+  &:hover {
+    color: ${(props) => props.theme.colors.grey[600]};
+  }
+  &.active {
+    color: ${(props) => props.theme.colors.primary.light};
+  }
+`
+
+export default GovernanceDropdown

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -14,9 +14,6 @@ const Nav: React.FC = () => {
       <ProductsDropdown />
       <GovernanceDropdown />
       <ResourcesDropdown />
-      <StyledLink exact activeClassName='active' to='/liquidity-mining'>
-        Liquidity Mining
-      </StyledLink>
     </StyledNav>
   )
 }

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { NavLink } from 'react-router-dom'
 import ProductsDropdown from './ProductsDropdown'
+import GovernanceDropdown from './GovernanceDropdown'
 import ResourcesDropdown from './ResourcesDropdown'
 
 const Nav: React.FC = () => {
@@ -11,16 +12,11 @@ const Nav: React.FC = () => {
         Home
       </StyledLink>
       <ProductsDropdown />
+      <GovernanceDropdown />
       <ResourcesDropdown />
       <StyledLink exact activeClassName='active' to='/liquidity-mining'>
         Liquidity Mining
       </StyledLink>
-      <StyledOutboundLink
-        href='https://institutions.indexcoop.com/'
-        target='_blank'
-      >
-        Institutions
-      </StyledOutboundLink>
     </StyledNav>
   )
 }

--- a/src/components/TopBar/components/ProductsDropdown.tsx
+++ b/src/components/TopBar/components/ProductsDropdown.tsx
@@ -19,7 +19,7 @@ const ProductsDropdown: React.FC = () => {
   const dropdownSelectStyles = useMemo(() => {
     const isProductRouteActive =
       pathname === '/dpi' ||
-      pathname === '/index' ||
+      pathname === '/mvi' ||
       pathname === '/ethfli' ||
       pathname === '/btcfli' ||
       pathname === '/bed'
@@ -95,11 +95,7 @@ const ProductsDropdown: React.FC = () => {
         {
           value: 'bed',
           label: 'Bankless BED Index',
-        },
-        {
-          value: 'index',
-          label: 'Index Coop Token',
-        },
+        }
       ]}
       components={{
         Option: CustomOption,

--- a/src/components/TopBar/components/ResourcesDropdown.tsx
+++ b/src/components/TopBar/components/ResourcesDropdown.tsx
@@ -33,10 +33,9 @@ const ProductsDropdown: React.FC = () => {
   const dropdownSelectStyles = useMemo(() => {
     const isResourcesRouteActive =
       pathname === '/about' ||
-      pathname === '/news' ||
-      pathname === '/rewards' ||
       pathname === '/how-to-buy' ||
-      pathname === '/vote'
+      pathname === '/news' ||
+      pathname === '/liquidity-mining'
 
     return {
       control: (styles: any) => ({
@@ -60,6 +59,7 @@ const ProductsDropdown: React.FC = () => {
       }),
       menu: (styles: any) => ({
         ...styles,
+        width: 200,
         color: 'black',
       }),
       dropdownIndicator: (styles: any) => ({
@@ -86,32 +86,28 @@ const ProductsDropdown: React.FC = () => {
   return (
     <Select
       isSearchable={false}
-      value={{ label: 'Resources' } as any}
+      value={{ label: 'Resources' }}
       options={[
         {
           value: 'about',
           label: 'About',
         },
         {
+          value: 'how-to-buy',
+          label: 'How to Buy',
+        },
+        {
           value: 'news',
           label: 'News',
         },
         {
-          value: 'docs',
-          label: 'Docs',
-          link: 'https://docs.indexcoop.com/',
+          value: 'liquidity-mining',
+          label: 'Liquidity Mining',
         },
         {
-          value: 'rewards',
-          label: 'Rewards',
-        },
-        {
-          value: 'vote',
-          label: 'Vote',
-        },
-        {
-          value: 'how-to-buy',
-          label: 'How to Buy',
+          value: 'institutions',
+          label: 'Institutions',
+          link: 'https://institutions.indexcoop.com/'
         },
       ]}
       components={{
@@ -123,7 +119,7 @@ const ProductsDropdown: React.FC = () => {
 }
 
 const CustomDropdownOption = styled.div`
-  width: 120px;
+  width: 190px;
   margin: 10px;
 `
 


### PR DESCRIPTION
Update nav dropdowns per the latest header [designs](https://bit.ly/index-coop-figma)
- Create a new Governance menu
- Move Index Coop Token under Governance
- Move Vote under Governance
- Move Handbook (previously labeled Docs) under Governance
- Move Rewards under Governance
- Move Liquidity Mining under Resources
- Move Institutions under Resources

Note to reviewers:
- I can't get `/news` to run in developer mode. I'm observing an
    unrelated React build error. Repro'ed on `master`.
- We should decide if we want social links (Discord, Twitter, Forum)
    under a new Community menu in the header nav or keep them in the
    footer. Thoughts @DevOnDefi ?

Before | After
--- | ---
![2021-08-10 23 46 42](https://user-images.githubusercontent.com/3699047/128967353-ed1bbbc4-f1aa-40db-952a-a03fab1917ed.gif) | ![2021-08-10 23 46 12](https://user-images.githubusercontent.com/3699047/128967342-83e569b8-f2bc-4741-ac4e-a40a241e36e4.gif)
