### PR TITLE
Fix exhaustive deps warnings

### DIFF
--- a/src/views/Farm/components/Stake/V3Farm.tsx
+++ b/src/views/Farm/components/Stake/V3Farm.tsx
@@ -62,7 +62,7 @@ const Stake: React.FC = () => {
     if (!indexTokenAddress) return
 
     onClaimAccrued(indexTokenAddress)
-  }, [indexTokenAddress, onClaimAccrued])
+  }, [onClaimAccrued])
 
   useEffect(() => {
     if (!indexTokenAddress) return
@@ -73,7 +73,6 @@ const Stake: React.FC = () => {
       )
     })
   }, [
-    indexTokenAddress,
     account,
     status,
     transactionStatus,


### PR DESCRIPTION
Fixes the following warnings observed in terminal after `yarn start`:
```
src/views/Farm/components/Stake/V3Farm.tsx
  Line 65:6:  React Hook useCallback has an unnecessary dependency: 'indexTokenAddress'. Either exclude it or remove the dependency array. Outer scope values like 'indexTokenAddress' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
  Line 75:6:  React Hook useEffect has an unnecessary dependency: 'indexTokenAddress'. Either exclude it or remove the dependency array. Outer scope values like 'indexTokenAddress' aren't valid dependencies because mutating them doesn't re-render the component    react-hooks/exhaustive-deps
```

## **Type of Change**

- [X] Bug Fix

## **Test Data or Screenshots**

I tried to smoke test the V3 Uniswap LP workflow but I encountered an error

<img width="1009" alt="Screen Shot 2021-08-26 at 10 01 12 PM" src="https://user-images.githubusercontent.com/3699047/131060109-36f5fd3e-cf0e-4c77-932b-472b800225fb.png">

