### PR TITLE
Add headers to Cypress homepage test

### DIFF
--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -3,7 +3,11 @@
 describe('Homepage', () => {
   before(() => {
     cy.wait(3000)
-    cy.visit('http://localhost:3000/')
+    cy.visit('http://localhost:3000/', {
+      headers: {
+        "Accept-Encoding": "gzip, deflate"
+      }
+    })
   })
 
   context('HomeHeader', () => {


### PR DESCRIPTION
Attempt to fix the Cypress homepage test which is failing due to:
```error
  1) Homepage
       HomeHeader
         "before all" hook for "should exist":
     CypressError: `cy.visit()` failed trying to load:

http://localhost:3000/

We attempted to make an http request to this URL but the request failed without a response.

We received this error at the network level:

  > Error: ESOCKETTIMEDOUT
```

Fix is based on comments in https://github.com/cypress-io/cypress/issues/943