### PR TITLE
Increase response timeout for homepage test

### DIFF
--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -6,7 +6,8 @@ describe('Homepage', () => {
     cy.visit('http://localhost:3000/', {
       headers: {
         "Accept-Encoding": "gzip, deflate"
-      }
+      },
+      responseTimeout: 31000
     })
   })
 


### PR DESCRIPTION
Motivation in https://github.com/cypress-io/cypress/issues/7062#issuecomment-752458819
Attempt to fix:
```
  1) Homepage
       HomeHeader
         "before all" hook for "should exist":
     CypressError: `cy.visit()` failed trying to load:
```