### PR TITLE
Fix DATA img alt warning

### DIFF
--- a/src/views/DATA/DATA.tsx
+++ b/src/views/DATA/DATA.tsx
@@ -107,7 +107,7 @@ const DataProductPage = (props: { title: string }) => {
           weight of each token included in the index. The weight of each token
           within the index will be as follows:
         </p>
-        <img src={dataEsotericMath} />
+        <img src={dataEsotericMath} alt="Data esoteric math" />
         <p>
           The Data Economy Index caps each token’s respective weight at 25%.
           Excess weight for a given token will be redistributed to the remaining


### PR DESCRIPTION
Fixes

<img width="1414" alt="Screen Shot 2021-09-28 at 11 27 24 PM" src="https://user-images.githubusercontent.com/3699047/135198251-238e8328-8a6d-4bc5-84b8-27dc425ce237.png">
 