### PR TITLE
Add Null Propagation operator in isOnto check to avoid page breaking …

### DIFF
--- a/src/hooks/useEagerConnect.ts
+++ b/src/hooks/useEagerConnect.ts
@@ -9,7 +9,7 @@ export default function useEagerConnect(
 
   // Connect to existing injected provider if app was opened from ONTO mobile wallet
   useEffect(() => {
-    if (!active && !tried && (window as any).ethereum.isONTO) {
+    if (!active && !tried && (window as any).ethereum?.isONTO) {
       connect('injected').catch(() => {
         setTried(true)
       })


### PR DESCRIPTION
…when window.ethereum is not set

# **Pull Request Template**

## **Type of Change**

###### *Select a category that relates to the content of your pull request (choose all that apply).*

- [ x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

###### *Provide a brief summary of the changes you made and their purpose as they relate to Index UI. <br/>If applicable, please link the corresponding issue number.*
App broke when running in incognitor mode or more generally when `window.ethereum` was undefined.
&nbsp;

### **Fixes: Issue #**


&nbsp;

## **Test Data or Screenshots**
![image](https://user-images.githubusercontent.com/15629702/136579425-dc587894-8aaf-4906-96c2-242fbe838bd6.png)

###### *Include proof that your changes function properly and resolve the linked issue.*

&nbsp;

## **Submission Reminders**

###### *By submitting this pull request, you are confirming the following to be true:*

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
