### PR TITLE
Fix "How To Buy" warnings

### DIFF
--- a/src/views/HowToBuy/HowToBuy.tsx
+++ b/src/views/HowToBuy/HowToBuy.tsx
@@ -466,7 +466,6 @@ const SectionTitle = styled.p`
 
 const SectionSubTitle = styled.p`
   font-size: 24px;
-  display: inline;
   line-height: 1.1;
   padding-bottom: 5px;
   border-bottom: 3px solid #a9a7ff;
@@ -499,7 +498,7 @@ const HeaderImage = styled.img`
   }
 `
 
-const Description = styled.p`
+const Description = styled.div`
   font-size: 24px;
   line-height: 1.4;
   @media (max-width: 768px) {


### PR DESCRIPTION
Resolves https://github.com/SetProtocol/index-ui/issues/396

### Screenshot

"How to Buy" page looks identical before and after this change.
Left: existing indexcoop.com
Right: indexcoop after this change

<img width="1422" alt="Screen Shot 2021-10-11 at 8 42 13 PM" src="https://user-images.githubusercontent.com/3699047/136871672-7b1f2ca9-1d6a-4e98-952b-1d48c81dd66a.png">

