### PR TITLE
Directly connect wallet upon clicking the wallet button when in onto app

### DIFF
--- a/src/components/TopBar/components/WalletButton.tsx
+++ b/src/components/TopBar/components/WalletButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import { Button } from 'react-neu'
@@ -13,7 +13,18 @@ const WalletButton: React.FC = () => {
     isShowingWalletModal,
     onCloseWalletModal,
     onOpenWalletModal,
+    status,
+    connect,
   } = useWallet()
+
+  const onClick = useCallback(() => {
+    // If the user comes from the onto app it should directly connect without opening the web3 modal
+    if (status != 'connected' && (window as any).ethereum?.isONTO) {
+      connect('injected')
+    } else {
+      onOpenWalletModal()
+    }
+  }, [status, connect])
 
   const openWalletText = !!account ? 'View Balances' : 'Unlock Wallet'
   const variant = !!account ? 'tertiary' : 'default'
@@ -22,7 +33,7 @@ const WalletButton: React.FC = () => {
     <>
       <StyledWalletButton>
         <Button
-          onClick={onOpenWalletModal}
+          onClick={onClick}
           size='sm'
           text={openWalletText}
           variant={variant}


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### *Select a category that relates to the content of your pull request (choose all that apply).*

- [ x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

###### *Provide a brief summary of the changes you made and their purpose as they relate to Index UI. <br/>If applicable, please link the corresponding issue number.*
- Old Behavkour: If the user visits the index page from the onto mobile wallet and then manually disconnects his wallet, he has to click the "metamask" option in the web3 modal to reconnect
- New Behaviour: When the user clicks "connect wallet" from the onto app, the wallet connects directly without even opening the wallet selection modal.
&nbsp;

### **Fixes: Issue #**
https://www.notion.so/index-coop/Adjust-ONTO-connection-button-83110893da8440e29ca91ee6601cffbd
&nbsp;

## **Test Data or Screenshots**

###### *Include proof that your changes function properly and resolve the linked issue.*
https://photos.google.com/share/AF1QipPqv-Y8O-9J0_lQHtl9FVnvi1BjJCLd-SOnpPCwyGO70T5Y-o0c3teCN0lj_HzySg/photo/AF1QipO0ZkknFkWg7i42NV35yTjmvhx8A4q94WM_EMcp?key=c3loZncxS1A2cDFraUpBZ1RlT24tR2tjUnNKMHRn

&nbsp;

## **Submission Reminders**

###### *By submitting this pull request, you are confirming the following to be true:*

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
