### PR TITLE
fix: update expired Discord links: footer, about, readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ Some general troubleshooting guidelines to consider:
 [1]:    https://docs.google.com/forms/d/e/1FAIpQLSfzG2faWGFkaNuwJMwFaFKHAIgSSRCbtyKGwsmgJhefYoTHbQ/viewform                                                                                 "index welcome form"
 [2]:    https://docs.indexcoop.com/                                                                                                                                                         "index handbook"
 [3]:    https://github.com/SetProtocol/index-ui/blob/master/CODE_OF_CONDUCT.md/                                                                                                             "code of conduct"
-[4]:    https://discord.com/invite/VaEV9d4V                                                                                                                                                 "index discord"
+[4]:    https://discord.com/invite/74xXr57XHT                                                                                                                                                 "index discord"
 [5]:    https://www.indexcoop.com/                                                                                                                                                          "index website"
 [6]:    https://www.indexcoop.com/about                                                                                                                                                     "index about"
 [7]:    https://www.indexcoop.com/news                                                                                                                                                      "index news"

--- a/src/components/Footer/components/Nav.tsx
+++ b/src/components/Footer/components/Nav.tsx
@@ -1,13 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { discordLink } from 'constants/externalLinks'
+
 const Nav: React.FC = () => {
   return (
-    <StyledNav data-cy="footer-links">
-      <StyledLink href="https://twitter.com/indexcoop">Twitter</StyledLink>
-      <StyledLink href="https://gov.indexcoop.com">Forum</StyledLink>
-      <StyledLink href="https://discord.gg/RKZ4S3b">Discord</StyledLink>
-      <StyledLink href="https://index-dao.s3.amazonaws.com/index-logo-pack.zip" download>Logos</StyledLink>
+    <StyledNav data-cy='footer-links'>
+      <StyledLink href='https://twitter.com/indexcoop'>Twitter</StyledLink>
+      <StyledLink href='https://gov.indexcoop.com'>Forum</StyledLink>
+      <StyledLink href={discordLink}>Discord</StyledLink>
+      <StyledLink
+        href='https://index-dao.s3.amazonaws.com/index-logo-pack.zip'
+        download
+      >
+        Logos
+      </StyledLink>
     </StyledNav>
   )
 }
@@ -18,12 +25,12 @@ const StyledNav = styled.nav`
 `
 
 const StyledLink = styled.a`
-  color: ${props => props.theme.colors.grey[500]};
-  padding-left: ${props => props.theme.spacing[3]}px;
-  padding-right: ${props => props.theme.spacing[3]}px;
+  color: ${(props) => props.theme.colors.grey[500]};
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
   text-decoration: none;
   &:hover {
-    color: ${props => props.theme.colors.grey[600]};
+    color: ${(props) => props.theme.colors.grey[600]};
   }
 `
 

--- a/src/views/About/About.tsx
+++ b/src/views/About/About.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Container } from 'react-neu'
 import { useTheme } from 'react-neu'
 
+import { discordLink } from 'constants/externalLinks'
 import Page from 'components/Page'
 
 const About = (props: { title: string }) => {
@@ -109,7 +110,7 @@ const About = (props: { title: string }) => {
           </LargeDescription>
           <ButtonContainer data-cy='join-us-buttons'>
             <ButtonLink
-              href='https://discord.gg/XNMVW4Egdr'
+              href={discordLink}
               target='_blank'
               rel='noopener'
               style={{ marginRight: '30px' }}


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### *Select a category that relates to the content of your pull request (choose all that apply).*

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**
BUG: Discord links are expired. This issue was reported by Lemonade https://discord.com/channels/762061559744299010/762062707548487691/902279406838493256

!! While the updated link currently works, I was not able to confirm if it is the best link.

Updated existing expired Discord link in three locations:

- /about -> Join Us section
- footer
- CONTRIBUTING.md

&nbsp;

### **Fixes: Issue #**

&nbsp;

## **Test Data or Screenshots**

Tested updated link locally

<img width="864" alt="Screen Shot 2021-10-26 at 8 22 06 PM" src="https://user-images.githubusercontent.com/13758946/138849939-8c3ee2be-fdac-45a5-9965-6c5ab7e01d2e.png">

&nbsp;

## **Submission Reminders**

###### *By submitting this pull request, you are confirming the following to be true:*

This my first PR here, so appreciate any guidance.

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index
-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
