### PR TITLE
Implements fallback component for when Sheets API keys/Sheet IDs are not present

### DIFF
--- a/src/utils/newsApi.ts
+++ b/src/utils/newsApi.ts
@@ -13,6 +13,12 @@ const fetchNews = async () => {
     rows = await sheet.getRows()
   } catch (err) {
     console.error(err)
+    if (process.env.NODE_ENV !== 'production') {
+      return [err]
+    }
+  }
+  if (rows.length === 0 && process.env.NODE_ENV !== 'production') {
+    return ['No data in sheet']
   }
 
   let news = rows.map((row: any) => {

--- a/src/views/News/News.tsx
+++ b/src/views/News/News.tsx
@@ -3,6 +3,7 @@ import { Container, Spacer } from 'react-neu'
 import Page from 'components/Page'
 import styled from 'styled-components'
 import HeaderNewsCard from './components/HeaderNewsCard'
+import HeaderNewsNotFound from './components/HeaderNewsNotFound'
 import NewsCard from './components/NewsCard'
 import fetchNews from 'utils/newsApi'
 import NewsCardPlaceholder from './components/NewsCardPlaceholder'
@@ -29,7 +30,14 @@ const Vote = (props: { title: string }) => {
   }, [])
 
   let header =
-    headerArticle.title === '' ? null : (
+    !headerArticle || !headerArticle.title ? (
+      <>
+        <HeaderNewsNotFound />
+        {process.env.NODE_ENV !== 'production' ? (
+          <p>{headerArticle.toString()}</p>
+        ) : null}
+      </>
+    ) : (
       <HeaderNewsCard
         image={headerArticle.image}
         title={headerArticle.title}

--- a/src/views/News/components/HeaderNewsNotFound.tsx
+++ b/src/views/News/components/HeaderNewsNotFound.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const HeaderNewsNotFound: React.FC = () => {
+  return (
+    <StyledCard target='_blank'>
+      <StyledCardContent>
+        <StyledCardTitle>
+          Oops! There's a problem with news we're working on right now!
+        </StyledCardTitle>
+      </StyledCardContent>
+    </StyledCard>
+  )
+}
+
+const StyledCard = styled.a`
+  width: 100%;
+  transition: 0.2s;
+  cursor: pointer;
+  text-decoration: none;
+  &:hover {
+    color: ${(props) => props.theme.colors.primary.light};
+  }
+`
+
+const StyledCardContent = styled.div`
+  height: 100px;
+  width: 100%;
+`
+
+const StyledCardTitle = styled.p`
+  display: block;
+  font-size: 32px;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  font-weight: 600;
+  color: ${(props) => props.theme.textColor};
+`
+
+export default HeaderNewsNotFound


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### *Select a category that relates to the content of your pull request (choose all that apply).*

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

###### *Provide a brief summary of the changes you made and their purpose as they relate to Index UI. <br/>If applicable, please link the corresponding issue number.*

App crashes on News page when trying to API pull news from google sheet if API key and/or Sheet ID is not specified. Added component to present gracefully to user (as well as a dev environment reminder):

&nbsp;

### **Fixes #425 **

&nbsp;

## **Test Data or Screenshots**

###### *Include proof that your changes function properly and resolve the linked issue.*
When key/id is omitted (returns error string from sheets API):
![image](https://user-images.githubusercontent.com/25326067/138963343-21fa02eb-edfc-4645-a59b-7d7ba68daf47.png)

Also need to check valid sheet/api key when sheet headers are present but no data rows exist:

![image](https://user-images.githubusercontent.com/25326067/138963625-4b955d69-8225-41d1-8eb7-85f3e2b2c4ee.png)

Working result:

![image](https://user-images.githubusercontent.com/25326067/138964322-fcc8171c-e487-41d7-8de2-807e52324bb8.png)


&nbsp;

## **Submission Reminders**

###### *By submitting this pull request, you are confirming the following to be true:*

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
