### PR TITLE
Remove residual logo console.log

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -15,8 +15,6 @@ const Logo: React.FC = () => {
     logo = darkMode ? indexLogoFullWhite : indexLogoFullBlack
   else logo = darkMode ? indexLogoWhite : indexLogoBlack
 
-  console.log(window.innerWidth)
-
   return (
     <StyledLogo to='/'>
       <StyledImage src={logo} alt='index-logo' />


### PR DESCRIPTION
I've memorized this logo width by now.

Before | After
--- | ---
<img width="389" alt="Screen Shot 2021-11-15 at 7 03 14 PM" src="https://user-images.githubusercontent.com/3699047/141871925-473ba3fe-a10e-425b-84d8-906ef90dd778.png"> | <img width="607" alt="Screen Shot 2021-11-15 at 7 05 07 PM" src="https://user-images.githubusercontent.com/3699047/141871934-87bb836a-fa1a-4087-8c4d-d862527f14f0.png">

Notice no more 1920