### PR TITLE
Display ENS name for connected wallet

### DIFF
--- a/cypress/integration/walletConnection.spec.js
+++ b/cypress/integration/walletConnection.spec.js
@@ -5,6 +5,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return false
 })
 
+const testRunnerShortAddress = '0xf39F...2266'
+
 describe('Wallet Connection', () => {
   context('Metamask', () => {
     before(() => {
@@ -16,14 +18,14 @@ describe('Wallet Connection', () => {
       })
     })
     it('should be able to connect', () => {
-      cy.contains('Unlock Wallet').click()
+      cy.contains('Connect Wallet').click()
       cy.contains('Metamask').parent().parent().contains('Select').click()
-      cy.contains('View Balances')
+      cy.contains(testRunnerShortAddress)
     })
     it('should be able to disconnect', () => {
-      cy.contains('View Balances').parent().click()
+      cy.contains(testRunnerShortAddress).parent().click()
       cy.contains('Sign Out').click()
-      cy.contains('Unlock Wallet')
+      cy.contains('Connect Wallet')
     })
   })
 
@@ -33,16 +35,16 @@ describe('Wallet Connection', () => {
       cy.reload(true)
     })
     it('should connect directly', () => {
-      cy.contains('View Balances').should('be.visible')
+      cy.contains(testRunnerShortAddress).should('be.visible')
     })
     it('should be able to disconnect', () => {
-      cy.contains('View Balances').parent().click()
+      cy.contains(testRunnerShortAddress).parent().click()
       cy.contains('Sign Out').click()
-      cy.contains('Unlock Wallet').should('be.visible')
+      cy.contains('Connect Wallet').should('be.visible')
     })
-    it('should reconnect directly when clicking Unlock wallet button', () => {
-      cy.contains('Unlock Wallet').click()
-      cy.contains('View Balances').should('be.visible')
+    it('should reconnect directly when clicking Connect Wallet button', () => {
+      cy.contains('Connect Wallet').click()
+      cy.contains(testRunnerShortAddress).should('be.visible')
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "@usedapp/core": "^0.5.5",
     "apollo-client": "^2.6.10",
     "axios": "^0.24.0",
     "bignumber.js": "^9.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ToastContainer, Slide } from 'react-toastify'
 import { ApolloProvider } from '@apollo/client'
 import styled from 'styled-components'
 import 'react-toastify/dist/ReactToastify.css'
+import { ChainId, DAppProvider, Config } from '@usedapp/core'
 
 import MobileMenu from 'components/MobileMenu'
 import TopBar from 'components/TopBar'
@@ -135,6 +136,10 @@ const App: React.FC = () => {
   )
 }
 
+const config: Config = {
+  readOnlyChainId: ChainId.Mainnet,
+}
+
 const Providers: React.FC = ({ children }) => {
   const [darkModeSetting] = useLocalStorage('darkMode', true)
   const { dark: darkTheme, light: lightTheme } = useMemo(() => {
@@ -149,65 +154,67 @@ const Providers: React.FC = ({ children }) => {
     >
       <TransactionWatcherProvider>
         <WalletProvider>
-          <ApolloProvider client={graphqlClient}>
-            <MediaQueryProvider>
-              <AirdropProvider>
-                <RewardsProvider>
-                  <ExternalAirdropProvider>
-                    <BalancesProvider>
-                      <FarmingProvider>
-                        <FarmingTwoProvider>
-                          <MviStakingRewardsProvider>
-                            <PricesProvider>
-                              <BuySellProvider>
-                                <Eth2xFliTokenMarketDataProvider>
-                                  <Eth2xFliIndexPortfolioDataProvider>
-                                    <Eth2xFliTokenSupplyCapProvider>
-                                      <Btc2xFliTokenMarketDataProvider>
-                                        <Btc2xFliPortfolioDataProvider>
-                                          <Btc2xFliTokenSupplyCapProvider>
-                                            <DpiTokenMarketDataProvider>
-                                              <DpiIndexComponentsProvider>
-                                                <MviTokenMarketDataProvider>
-                                                  <MviComponentsProvider>
-                                                    <BedTokenMarketDataProvider>
-                                                      <BedIndexComponentsProvider>
-                                                        <DataTokenMarketDataProvider>
-                                                          <DataComponentsProvider>
-                                                            <IndexTokenMarketDataProvider>
-                                                              <V3FarmingProvider>
-                                                                <StreamingFeeProvider>
-                                                                  <TokenSupplyProvider>
-                                                                    {children}
-                                                                  </TokenSupplyProvider>
-                                                                </StreamingFeeProvider>
-                                                              </V3FarmingProvider>
-                                                            </IndexTokenMarketDataProvider>
-                                                          </DataComponentsProvider>
-                                                        </DataTokenMarketDataProvider>
-                                                      </BedIndexComponentsProvider>
-                                                    </BedTokenMarketDataProvider>
-                                                  </MviComponentsProvider>
-                                                </MviTokenMarketDataProvider>
-                                              </DpiIndexComponentsProvider>
-                                            </DpiTokenMarketDataProvider>
-                                          </Btc2xFliTokenSupplyCapProvider>
-                                        </Btc2xFliPortfolioDataProvider>
-                                      </Btc2xFliTokenMarketDataProvider>
-                                    </Eth2xFliTokenSupplyCapProvider>
-                                  </Eth2xFliIndexPortfolioDataProvider>
-                                </Eth2xFliTokenMarketDataProvider>
-                              </BuySellProvider>
-                            </PricesProvider>
-                          </MviStakingRewardsProvider>
-                        </FarmingTwoProvider>
-                      </FarmingProvider>
-                    </BalancesProvider>
-                  </ExternalAirdropProvider>
-                </RewardsProvider>
-              </AirdropProvider>
-            </MediaQueryProvider>
-          </ApolloProvider>
+          <DAppProvider config={config}>
+            <ApolloProvider client={graphqlClient}>
+              <MediaQueryProvider>
+                <AirdropProvider>
+                  <RewardsProvider>
+                    <ExternalAirdropProvider>
+                      <BalancesProvider>
+                        <FarmingProvider>
+                          <FarmingTwoProvider>
+                            <MviStakingRewardsProvider>
+                              <PricesProvider>
+                                <BuySellProvider>
+                                  <Eth2xFliTokenMarketDataProvider>
+                                    <Eth2xFliIndexPortfolioDataProvider>
+                                      <Eth2xFliTokenSupplyCapProvider>
+                                        <Btc2xFliTokenMarketDataProvider>
+                                          <Btc2xFliPortfolioDataProvider>
+                                            <Btc2xFliTokenSupplyCapProvider>
+                                              <DpiTokenMarketDataProvider>
+                                                <DpiIndexComponentsProvider>
+                                                  <MviTokenMarketDataProvider>
+                                                    <MviComponentsProvider>
+                                                      <BedTokenMarketDataProvider>
+                                                        <BedIndexComponentsProvider>
+                                                          <DataTokenMarketDataProvider>
+                                                            <DataComponentsProvider>
+                                                              <IndexTokenMarketDataProvider>
+                                                                <V3FarmingProvider>
+                                                                  <StreamingFeeProvider>
+                                                                    <TokenSupplyProvider>
+                                                                      {children}
+                                                                    </TokenSupplyProvider>
+                                                                  </StreamingFeeProvider>
+                                                                </V3FarmingProvider>
+                                                              </IndexTokenMarketDataProvider>
+                                                            </DataComponentsProvider>
+                                                          </DataTokenMarketDataProvider>
+                                                        </BedIndexComponentsProvider>
+                                                      </BedTokenMarketDataProvider>
+                                                    </MviComponentsProvider>
+                                                  </MviTokenMarketDataProvider>
+                                                </DpiIndexComponentsProvider>
+                                              </DpiTokenMarketDataProvider>
+                                            </Btc2xFliTokenSupplyCapProvider>
+                                          </Btc2xFliPortfolioDataProvider>
+                                        </Btc2xFliTokenMarketDataProvider>
+                                      </Eth2xFliTokenSupplyCapProvider>
+                                    </Eth2xFliIndexPortfolioDataProvider>
+                                  </Eth2xFliTokenMarketDataProvider>
+                                </BuySellProvider>
+                              </PricesProvider>
+                            </MviStakingRewardsProvider>
+                          </FarmingTwoProvider>
+                        </FarmingProvider>
+                      </BalancesProvider>
+                    </ExternalAirdropProvider>
+                  </RewardsProvider>
+                </AirdropProvider>
+              </MediaQueryProvider>
+            </ApolloProvider>
+          </DAppProvider>
         </WalletProvider>
       </TransactionWatcherProvider>
       <ToastContainer transition={Slide} position='bottom-left' />

--- a/src/components/TopBar/components/WalletButton.tsx
+++ b/src/components/TopBar/components/WalletButton.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
-
 import { Button } from 'react-neu'
-import useWallet from 'hooks/useWallet'
+import { shortenAddress, useLookupAddress } from '@usedapp/core'
 
+import useWallet from 'hooks/useWallet'
 import UnlockWalletModal from 'components/UnlockWalletModal'
 import WalletModal from 'components/WalletModal'
 
@@ -16,6 +16,7 @@ const WalletButton: React.FC = () => {
     status,
     connect,
   } = useWallet()
+  const ens = useLookupAddress()
 
   const onClick = useCallback(() => {
     // If the user comes from the onto app it should directly connect without opening the web3 modal
@@ -26,7 +27,7 @@ const WalletButton: React.FC = () => {
     }
   }, [status, connect, onOpenWalletModal])
 
-  const openWalletText = !!account ? 'View Balances' : 'Unlock Wallet'
+  const openWalletText = getOpenWalletText(account, ens)
   const variant = !!account ? 'tertiary' : 'default'
 
   return (
@@ -49,6 +50,16 @@ const WalletButton: React.FC = () => {
       />
     </>
   )
+}
+
+function getOpenWalletText(account: string | null | undefined, ens: string | null | undefined) {
+  if (account && ens) {
+    return ens
+  } else if (account) {
+    return shortenAddress(account)
+  } else {
+    return 'Connect wallet'
+  }
 }
 
 const StyledWalletButton = styled.div``

--- a/src/components/TopBar/components/WalletButton.tsx
+++ b/src/components/TopBar/components/WalletButton.tsx
@@ -58,7 +58,7 @@ function getOpenWalletText(account: string | null | undefined, ens: string | nul
   } else if (account) {
     return shortenAddress(account)
   } else {
-    return 'Connect wallet'
+    return 'Connect Wallet'
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,7 +1612,7 @@
     "@ethereumjs/common" "^2.4.0"
     ethereumjs-util "^7.1.0"
 
-"@ethersproject/abi@5.0.0-beta.153", "@ethersproject/abi@5.0.7", "@ethersproject/abi@5.4.1", "@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0":
+"@ethersproject/abi@5.0.0-beta.153", "@ethersproject/abi@5.0.7", "@ethersproject/abi@5.4.0", "@ethersproject/abi@5.4.1", "@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
   integrity sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==
@@ -1626,6 +1626,19 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/abstract-provider@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz#415331031b0f678388971e1987305244edc04e1d"
+  integrity sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
 
 "@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.1"
@@ -1652,6 +1665,17 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/web" "^5.5.0"
+
+"@ethersproject/abstract-signer@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz#cd5f50b93141ee9f9f49feb4075a0b3eafb57d65"
+  integrity sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
 
 "@ethersproject/abstract-signer@5.4.1", "@ethersproject/abstract-signer@^5.4.0":
   version "5.4.1"
@@ -1727,7 +1751,7 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
 
-"@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.4.0", "@ethersproject/bignumber@^5.5.0":
+"@ethersproject/bignumber@5.4.0", "@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.4.0", "@ethersproject/bignumber@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
   integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
@@ -1763,6 +1787,22 @@
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/contracts@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.0.tgz#e05fe6bd33acc98741e27d553889ec5920078abb"
+  integrity sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==
+  dependencies:
+    "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
 
 "@ethersproject/contracts@5.4.1":
   version "5.4.1"
@@ -1905,6 +1945,11 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/logger@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
+  integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
 "@ethersproject/logger@5.4.1", "@ethersproject/logger@^5.4.0":
   version "5.4.1"
   resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz"
@@ -1914,6 +1959,13 @@
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/networks@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.4.1.tgz#2ce83b8e42aa85216e5d277a7952d97b6ce8d852"
+  integrity sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
 
 "@ethersproject/networks@5.4.2", "@ethersproject/networks@^5.4.0":
   version "5.4.2"
@@ -1945,6 +1997,13 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/sha2" "^5.5.0"
 
+"@ethersproject/properties@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
+  integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
 "@ethersproject/properties@5.4.1", "@ethersproject/properties@^5.4.0":
   version "5.4.1"
   resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz"
@@ -1959,7 +2018,7 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
-"@ethersproject/providers@5.4.5", "@ethersproject/providers@5.5.0":
+"@ethersproject/providers@5.4.1", "@ethersproject/providers@5.4.5", "@ethersproject/providers@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.0.tgz#bc2876a8fe5e0053ed9828b1f3767ae46e43758b"
   integrity sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==
@@ -3367,6 +3426,14 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.1.tgz#eb1f1407dea8da3bc741879c1192aa703ab9975b"
+  integrity sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/recharts@^1.8.16":
   version "1.8.19"
   resolved "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.19.tgz"
@@ -3619,6 +3686,19 @@
     "@typescript-eslint/types" "4.31.0"
     eslint-visitor-keys "^2.0.0"
 
+"@usedapp/core@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@usedapp/core/-/core-0.5.5.tgz#651d8b4e2fc85a19935e0b3ec1495a103b8b75b6"
+  integrity sha512-2a/ttaD0fY1Ui7ubB0pVEzi15euuKr8a/oiXs4rWH8qrth+jW38QyImvl7xQVO63Ikq2pKqmBOJbSFVubdHNDw==
+  dependencies:
+    "@types/react" "17.0.1"
+    "@web3-react/core" "6.1.1"
+    "@web3-react/injected-connector" "6.0.7"
+    "@web3-react/network-connector" "6.1.5"
+    ethers "5.4.1"
+    lodash.merge "^4.6.2"
+    nanoid "3.1.22"
+
 "@walletconnect/browser-utils@^1.6.5":
   version "1.6.5"
   resolved "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.6.5.tgz"
@@ -3796,6 +3876,17 @@
   dependencies:
     "@web3-react/types" "^6.0.7"
 
+"@web3-react/core@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@web3-react/core/-/core-6.1.1.tgz#06c853890723f600b387b738a4b71ef41d5cccb7"
+  integrity sha512-HKXOgPNCmFvrVsed+aW/HlVhwzs8t3b+nzg3BoxgJQo/5yLiJXSumHRBdUrPxhBQiHkHRZiVPAvzf/8JMnm74Q==
+  dependencies:
+    "@ethersproject/keccak256" "^5.0.0-beta.130"
+    "@web3-react/abstract-connector" "^6.0.7"
+    "@web3-react/types" "^6.0.7"
+    tiny-invariant "^1.0.6"
+    tiny-warning "^1.0.3"
+
 "@web3-react/core@^6.1.1":
   version "6.1.9"
   resolved "https://registry.npmjs.org/@web3-react/core/-/core-6.1.9.tgz"
@@ -3827,7 +3918,7 @@
     eth-provider "^0.2.5"
     tiny-invariant "^1.0.6"
 
-"@web3-react/injected-connector@^6.0.7":
+"@web3-react/injected-connector@6.0.7", "@web3-react/injected-connector@^6.0.7":
   version "6.0.7"
   resolved "https://registry.npmjs.org/@web3-react/injected-connector/-/injected-connector-6.0.7.tgz"
   integrity sha512-Y7aJSz6pg+MWKtvdyuqyy6LWuH+4Tqtph1LWfiyVms9II9ar/9B/de4R8wh4wjg91wmHkU+D75yP09E/Soh2RA==
@@ -3844,6 +3935,15 @@
     "@0x/subproviders" "^5.0.4"
     "@web3-react/abstract-connector" "^6.0.7"
     "@web3-react/types" "^6.0.7"
+
+"@web3-react/network-connector@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@web3-react/network-connector/-/network-connector-6.1.5.tgz#1fcce1dc7b03dac23fcc01ad0b0c870cb0e39e0b"
+  integrity sha512-Uwk8iMG8YCnTeKmyXt3Q7QJN28qTs0YTTW8/aes2R26KmYWCk3GdL2eal0QcXUixJy/IjrhXzbwzHgpneJqrWg==
+  dependencies:
+    "@web3-react/abstract-connector" "^6.0.7"
+    "@web3-react/types" "^6.0.7"
+    tiny-invariant "^1.0.6"
 
 "@web3-react/portis-connector@^6.1.6":
   version "6.1.9"
@@ -8977,6 +9077,42 @@ ethers@4.0.0-beta.14:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
+ethers@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.1.tgz#bcff1e9f45bf1a061bf313ec04e8d9881d2d53f9"
+  integrity sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==
+  dependencies:
+    "@ethersproject/abi" "5.4.0"
+    "@ethersproject/abstract-provider" "5.4.0"
+    "@ethersproject/abstract-signer" "5.4.0"
+    "@ethersproject/address" "5.4.0"
+    "@ethersproject/base64" "5.4.0"
+    "@ethersproject/basex" "5.4.0"
+    "@ethersproject/bignumber" "5.4.0"
+    "@ethersproject/bytes" "5.4.0"
+    "@ethersproject/constants" "5.4.0"
+    "@ethersproject/contracts" "5.4.0"
+    "@ethersproject/hash" "5.4.0"
+    "@ethersproject/hdnode" "5.4.0"
+    "@ethersproject/json-wallets" "5.4.0"
+    "@ethersproject/keccak256" "5.4.0"
+    "@ethersproject/logger" "5.4.0"
+    "@ethersproject/networks" "5.4.1"
+    "@ethersproject/pbkdf2" "5.4.0"
+    "@ethersproject/properties" "5.4.0"
+    "@ethersproject/providers" "5.4.1"
+    "@ethersproject/random" "5.4.0"
+    "@ethersproject/rlp" "5.4.0"
+    "@ethersproject/sha2" "5.4.0"
+    "@ethersproject/signing-key" "5.4.0"
+    "@ethersproject/solidity" "5.4.0"
+    "@ethersproject/strings" "5.4.0"
+    "@ethersproject/transactions" "5.4.0"
+    "@ethersproject/units" "5.4.0"
+    "@ethersproject/wallet" "5.4.0"
+    "@ethersproject/web" "5.4.0"
+    "@ethersproject/wordlists" "5.4.0"
+
 ethers@5.4.6:
   version "5.4.6"
   resolved "https://registry.npmjs.org/ethers/-/ethers-5.4.6.tgz"
@@ -13147,6 +13283,11 @@ nano-json-stream-parser@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
+
+nanoid@3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
 
 nanoid@^3.1.23:
   version "3.1.25"


### PR DESCRIPTION
## Motivation
ENS airdrop last week 🎉🥳 Let's make indexcoop.com ENS aware

## Description
1. Change "Unlock wallet" to "Connect wallet" because the latter seems more common on Web3 sites
2. Display ENS name for connected wallet (if user has an ENS). If not, fallback to shortened version of their public address.

Scenario | Screenshot
--- | ---
Not connected | <img width="174" alt="ens-not-connected" src="https://user-images.githubusercontent.com/3699047/141877319-e27c64d0-dc4b-498c-b6d8-021642fcb033.png">
Connected without ENS | <img width="153" alt="ens-without-ens" src="https://user-images.githubusercontent.com/3699047/141877339-695d3f11-8111-405e-846e-0d5d5f2b0d28.png">
Connected with ENS | <img width="135" alt="ens-with-ens" src="https://user-images.githubusercontent.com/3699047/141877381-fa352ecb-fe6a-4545-98cf-07d4293b1d47.png">

## Bundle size

This introduces a new dependency on [useDapp](https://usedapp.readthedocs.io/en/latest/) which increases our bundle size by approx. (1.97MB - 1.89MB) = .08MB
Before | After
--- | ---
<img width="742" alt="bundle-size-before" src="https://user-images.githubusercontent.com/3699047/141877239-45ca42af-f29f-4f3a-bc3d-4d337df72a57.png"> | <img width="755" alt="bundle-size-after" src="https://user-images.githubusercontent.com/3699047/141877250-1b01081c-6475-4f9f-8298-5ee3f3856e8c.png">