### PR TITLE
Prettier --write src/**

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
     "@types/styled-components": "^5.1.15",
     "@types/web3": "^1.2.2",
     "cypress": "^9.1.0",
-    "husky": "^4.3.0",
+    "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
-    "prettier": "2.5.0",
+    "prettier": "^2.5.0",
     "react-circular-progressbar": "^2.0.4",
     "typescript": "^4.4.4"
   },

--- a/src/components/ProductPage/ProductIndexComponentsTable.tsx
+++ b/src/components/ProductPage/ProductIndexComponentsTable.tsx
@@ -10,7 +10,7 @@ interface ProductIndexComponentsProps {
 }
 
 const ProductIndexComponentsTable: React.FC<ProductIndexComponentsProps> = ({
-  components
+  components,
 }) => {
   const [amountToDisplay, setAmountToDisplay] = useState<number>(5)
   const showAllComponents = () =>
@@ -76,14 +76,8 @@ interface ComponentRowProps {
 }
 
 const ComponentRow: React.FC<ComponentRowProps> = ({ component }) => {
-  const {
-    symbol,
-    quantity,
-    percentOfSet,
-    totalPriceUsd,
-    image,
-    name,
-  } = component
+  const { symbol, quantity, percentOfSet, totalPriceUsd, image, name } =
+    component
   const formattedPriceUSD = numeral(totalPriceUsd).format('$0,0.00')
 
   return (

--- a/src/components/TopBar/components/WalletButton.tsx
+++ b/src/components/TopBar/components/WalletButton.tsx
@@ -52,7 +52,10 @@ const WalletButton: React.FC = () => {
   )
 }
 
-function getOpenWalletText(account: string | null | undefined, ens: string | null | undefined) {
+function getOpenWalletText(
+  account: string | null | undefined,
+  ens: string | null | undefined
+) {
   if (account && ens) {
     return ens
   } else if (account) {

--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -1,7 +1,14 @@
 import React, { useState, useEffect } from 'react'
 import BigNumber from 'utils/bignumber'
 import { useQuery } from '@apollo/react-hooks'
-import { dpiTokenAddress, mviTokenAddress, bedTokenAddress, eth2xfliTokenAddress, btc2xfliTokenAddress, dataTokenAddress } from "constants/ethContractAddresses"
+import {
+  dpiTokenAddress,
+  mviTokenAddress,
+  bedTokenAddress,
+  eth2xfliTokenAddress,
+  btc2xfliTokenAddress,
+  dataTokenAddress,
+} from 'constants/ethContractAddresses'
 
 import PricesContext from './PricesContext'
 
@@ -89,7 +96,14 @@ const PricesProvider: React.FC = ({ children }) => {
   }, [])
 
   useEffect(() => {
-    const productAddresses = [dpiTokenAddress, mviTokenAddress, bedTokenAddress, eth2xfliTokenAddress, btc2xfliTokenAddress, dataTokenAddress]
+    const productAddresses = [
+      dpiTokenAddress,
+      mviTokenAddress,
+      bedTokenAddress,
+      eth2xfliTokenAddress,
+      btc2xfliTokenAddress,
+      dataTokenAddress,
+    ]
     const coinGeckoPriceUrl = `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${productAddresses}&vs_currencies=usd`
 
     fetch(coinGeckoPriceUrl)
@@ -98,8 +112,12 @@ const PricesProvider: React.FC = ({ children }) => {
         setDpiPrice(response[dpiTokenAddress?.toLowerCase() as string].usd)
         setMviPrice(response[mviTokenAddress?.toLowerCase() as string].usd)
         setBedPrice(response[bedTokenAddress?.toLowerCase() as string].usd)
-        setEth2xfliPrice(response[eth2xfliTokenAddress?.toLowerCase() as string].usd)
-        setBtc2xfliPrice(response[btc2xfliTokenAddress?.toLowerCase() as string].usd)
+        setEth2xfliPrice(
+          response[eth2xfliTokenAddress?.toLowerCase() as string].usd
+        )
+        setBtc2xfliPrice(
+          response[btc2xfliTokenAddress?.toLowerCase() as string].usd
+        )
         setDataPrice(response[dataTokenAddress?.toLowerCase() as string].usd)
       })
       .catch((error) => console.error(error))

--- a/src/contexts/SetComponents/SetComponent.ts
+++ b/src/contexts/SetComponents/SetComponent.ts
@@ -1,56 +1,56 @@
-import { BigNumber } from "bignumber.js";
+import { BigNumber } from 'bignumber.js'
 
 export interface SetComponent {
-    /**
-     * Token address
-     * @example "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
-     */
-    address: string
+  /**
+   * Token address
+   * @example "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+   */
+  address: string
 
-    /**
-     * Token id
-     * @example "uniswap"
-     */
-    id: string
+  /**
+   * Token id
+   * @example "uniswap"
+   */
+  id: string
 
-    /**
-     * Token image URL
-     * @example "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-uni.png"
-     */
-    image: string
+  /**
+   * Token image URL
+   * @example "https://assets.coingecko.com/coins/images/12504/thumb/uniswap-uni.png"
+   */
+  image: string
 
-    /**
-     * Token name
-     * @example "Uniswap"
-     */
-    name: string
+  /**
+   * Token name
+   * @example "Uniswap"
+   */
+  name: string
 
-    /**
-     * The percent of USD this component makes up in the Set.
-     * Equivalant to totalPriceUsd / total price of set in USD
-     */
-    percentOfSet: string
+  /**
+   * The percent of USD this component makes up in the Set.
+   * Equivalant to totalPriceUsd / total price of set in USD
+   */
+  percentOfSet: string
 
-    /**
-     * The percent of USD this component makes up in the Set.
-     * Equivalant to totalPriceUsd / total price of set in USD
-     */
-    percentOfSetNumber: BigNumber
+  /**
+   * The percent of USD this component makes up in the Set.
+   * Equivalant to totalPriceUsd / total price of set in USD
+   */
+  percentOfSetNumber: BigNumber
 
-    /**
-     * Quantity of component in the Set
-     */
-    quantity: string
+  /**
+   * Quantity of component in the Set
+   */
+  quantity: string
 
-    /**
-     * Token symbol
-     * @example "UNI"
-     */
-    symbol: string
+  /**
+   * Token symbol
+   * @example "UNI"
+   */
+  symbol: string
 
-    /**
-     * Total price of this component. This is equivalant to quantity of
-     * component * price of component.
-     */
-    totalPriceUsd: string
+  /**
+   * Total price of this component. This is equivalant to quantity of
+   * component * price of component.
+   */
+  totalPriceUsd: string
 }

--- a/src/contexts/SetComponents/SetComponentsContext.ts
+++ b/src/contexts/SetComponents/SetComponentsContext.ts
@@ -1,6 +1,5 @@
 import { createContext } from 'react'
-import { SetComponent } from "./SetComponent"
-
+import { SetComponent } from './SetComponent'
 
 interface SetComponentsProps {
   dpiComponents?: SetComponent[]

--- a/src/hooks/useSetComponents.ts
+++ b/src/hooks/useSetComponents.ts
@@ -1,8 +1,8 @@
-import { useContext } from "react";
-import { SetComponentsContext } from "../contexts/SetComponents";
+import { useContext } from 'react'
+import { SetComponentsContext } from '../contexts/SetComponents'
 
 function useSetComponents() {
-    return {...useContext(SetComponentsContext)}
+  return { ...useContext(SetComponentsContext) }
 }
 
-export default useSetComponents;
+export default useSetComponents

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -1,47 +1,48 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react'
 
 // CoinGecko ocassionaly throws 429s. We can temporarily mitigate by using
 // ONE_INCH_LIST instead however that doesn't contain some recent MVI additions
 // (e.g. WHALE)
-const COIN_GECKO_LIST = "https://tokens.coingecko.com/uniswap/all.json"
-const ONE_INCH_LIST = "https://wispy-bird-88a7.uniswap.workers.dev/?url=http://tokens.1inch.eth.link"
+const COIN_GECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
+const ONE_INCH_LIST =
+  'https://wispy-bird-88a7.uniswap.workers.dev/?url=http://tokens.1inch.eth.link'
 
 export interface Token {
-  address: string;
-  chainId: number;
-  name: string;
-  symbol: string;
-  decimals: number;
-  logoURI: string;
+  address: string
+  chainId: number
+  name: string
+  symbol: string
+  decimals: number
+  logoURI: string
 }
 
 export interface TokenList {
-  tokens: Token[];
+  tokens: Token[]
 }
 
 /**
  * Fetch Tokens from tokenlists
  * @link https://tokenlists.org/
  */
- export const fetchTokens = async (): Promise<Token[]> => {
-   try {
-     const res = await fetch(COIN_GECKO_LIST);
-     const data: TokenList = await res.json();
-     return data?.tokens;
-   } catch (e) {
-     console.error(e)
-     return [];
-   }
-};
+export const fetchTokens = async (): Promise<Token[]> => {
+  try {
+    const res = await fetch(COIN_GECKO_LIST)
+    const data: TokenList = await res.json()
+    return data?.tokens
+  } catch (e) {
+    console.error(e)
+    return []
+  }
+}
 
 export function useTokenList() {
-    const [tokenList, setTokenList] = useState<Token[]>();
+  const [tokenList, setTokenList] = useState<Token[]>()
 
-    useEffect(() => {
-        fetchTokens().then(data => {
-            setTokenList(data)
-        })
-    }, [])
+  useEffect(() => {
+    fetchTokens().then((data) => {
+      setTokenList(data)
+    })
+  }, [])
 
-    return {tokenList}
+  return { tokenList }
 }

--- a/src/utils/setjsApi.ts
+++ b/src/utils/setjsApi.ts
@@ -51,23 +51,33 @@ export async function getStreamingFees(
   return set.fees.batchFetchStreamingFeeInfoAsync(productAddresses)
 }
 
-export async function getSetDetails(web3Provider: provider, productAddresses: string[]): Promise<SetDetails[]> {
-  if (basicIssuanceModuleAddress === undefined ||
+export async function getSetDetails(
+  web3Provider: provider,
+  productAddresses: string[]
+): Promise<SetDetails[]> {
+  if (
+    basicIssuanceModuleAddress === undefined ||
     streamingFeeModuleAddress === undefined ||
     tradeModuleAddress === undefined ||
-    debtIssuanceModuleAddress === undefined) {
-    throw new Error("A set JS module address is not defined. Please check your .env file")
+    debtIssuanceModuleAddress === undefined
+  ) {
+    throw new Error(
+      'A set JS module address is not defined. Please check your .env file'
+    )
   }
 
-  const set = getSet(web3Provider);
+  const set = getSet(web3Provider)
   const moduleAddresses = [
     basicIssuanceModuleAddress,
     streamingFeeModuleAddress,
     tradeModuleAddress,
     debtIssuanceModuleAddress,
-  ];
+  ]
 
-  return set.setToken.batchFetchSetDetailsAsync(productAddresses, moduleAddresses);
+  return set.setToken.batchFetchSetDetailsAsync(
+    productAddresses,
+    moduleAddresses
+  )
 }
 
 function getSet(web3Provider: provider): Set {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6786,11 +6786,6 @@ commondir@^1.0.1:
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-compare-versions@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz"
-  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz"
@@ -9595,21 +9590,6 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
-find-versions@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz"
-  integrity sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
-  dependencies:
-    semver-regex "^3.1.2"
-
 find-yarn-workspace-root@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz"
@@ -10627,21 +10607,10 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^4.3.0:
-  version "4.3.8"
-  resolved "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz"
-  integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
-  dependencies:
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    compare-versions "^3.6.0"
-    cosmiconfig "^7.0.0"
-    find-versions "^4.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^5.0.0"
-    please-upgrade-node "^3.2.0"
-    slash "^3.0.0"
-    which-pm-runs "^1.0.0"
+husky@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -12536,13 +12505,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
@@ -13712,11 +13674,6 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-opencollective-postinstall@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
-
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz"
@@ -13871,13 +13828,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
 
 p-map@^2.0.0:
   version "2.1.0"
@@ -14179,13 +14129,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
-
 pkg-up@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz"
@@ -14199,13 +14142,6 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 pngjs@^3.3.0:
   version "3.4.0"
@@ -14964,7 +14900,7 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.5.0:
+prettier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
   integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
@@ -16549,16 +16485,6 @@ semaphore@>=1.0.1, semaphore@^1.0.3, semaphore@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz"
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
-
-semver-regex@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz"
-  integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
I followed the steps on https://create-react-app.dev/docs/setting-up-your-editor to try and have prettier run as a pre-commit hook but it doesn't appear to work as expected.

The diff in this PR was caused by:
```bash
./node_modules/.bin/prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"
```

I think we'll want to run `yarn lint:fix` or the above periodically until we have a CI check that ensures PRs aren't merged that don't conform to prettier