### PR TITLE
Re-enable 24hr percent change underlying tokens

### DIFF
--- a/src/components/ProductPage/ProductIndexComponentsTable.tsx
+++ b/src/components/ProductPage/ProductIndexComponentsTable.tsx
@@ -60,6 +60,7 @@ const ProductIndexComponentsTable: React.FC<ProductIndexComponentsProps> = ({
         </DisplayOnDesktopOnly>
 
         <StyledTableHeader>Allocation</StyledTableHeader>
+        <StyledTableHeader>24hr Change</StyledTableHeader>
 
         {components?.slice(0, amountToDisplay).map((data) => (
           <ComponentRow key={data.name} component={data} />
@@ -76,9 +77,20 @@ interface ComponentRowProps {
 }
 
 const ComponentRow: React.FC<ComponentRowProps> = ({ component }) => {
-  const { symbol, quantity, percentOfSet, totalPriceUsd, image, name } =
-    component
+  const {
+    symbol,
+    quantity,
+    percentOfSet,
+    totalPriceUsd,
+    dailyPercentChange,
+    image,
+    name,
+  } = component
   const formattedPriceUSD = numeral(totalPriceUsd).format('$0,0.00')
+
+  const absPercentChange = numeral(
+    Math.abs(parseFloat(dailyPercentChange))
+  ).format('0.00')
 
   return (
     <>
@@ -97,18 +109,23 @@ const ComponentRow: React.FC<ComponentRowProps> = ({ component }) => {
       </DisplayOnDesktopOnly>
 
       <StyledTableData>{percentOfSet}%</StyledTableData>
+      {parseFloat(dailyPercentChange) < 0 ? (
+        <NegativeChange>{absPercentChange}%</NegativeChange>
+      ) : (
+        <PositiveChange>{absPercentChange}%</PositiveChange>
+      )}
     </>
   )
 }
 
 const IndexComponentsTable = styled.div`
   display: grid;
-  grid-template-columns: [logo] 25px repeat(2, 1fr);
+  grid-template-columns: [logo] 25px repeat(3, 1fr);
   grid-column-gap: ${({ theme }) => theme.spacing[3]}px;
   grid-row-gap: ${({ theme }) => theme.spacing[4]}px;
 
   @media (min-width: 768px) {
-    grid-template-columns: [logo] 25px repeat(2, 1.5fr) repeat(2, 1fr);
+    grid-template-columns: [logo] 25px repeat(2, 1.5fr) repeat(3, 1fr);
   }
 `
 
@@ -130,6 +147,13 @@ const StyledTokenLogo = styled.img`
 const StyledTableData = styled(StyledTableHeader)`
   font-size: 16px;
   line-height: 24px;
+`
+
+const PositiveChange = styled(StyledTableData)`
+  color: ${({ theme }) => theme.colors.green};
+`
+const NegativeChange = styled(StyledTableData)`
+  color: ${({ theme }) => theme.colors.red};
 `
 
 const DisplayOnDesktopOnly = styled.span`

--- a/src/contexts/SetComponents/SetComponent.ts
+++ b/src/contexts/SetComponents/SetComponent.ts
@@ -53,4 +53,9 @@ export interface SetComponent {
    * component * price of component.
    */
   totalPriceUsd: string
+
+  /**
+   * Daily percent price change of this component
+   */
+  dailyPercentChange: string
 }

--- a/src/contexts/SetComponents/SetComponentsProvider.tsx
+++ b/src/contexts/SetComponents/SetComponentsProvider.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { provider } from 'web3-core'
 import BigNumber from 'bignumber.js'
-import { Position, SetDetails } from 'set.js/dist/types/src/types'
+import {
+  Position,
+  SetDetails,
+  CoinGeckoCoinPrices,
+} from 'set.js/dist/types/src/types'
 
 import SetComponentsContext from './SetComponentsContext'
 import { SetComponent } from './SetComponent'
@@ -70,7 +74,10 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            dpiComponentPrices[position.component.toLowerCase()]?.usd,
+            dpiComponentPrices[position.component.toLowerCase()]?.[VS_CURRENCY],
+            dpiComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             dpiPrice
           )
         })
@@ -83,7 +90,10 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            mviComponentPrices[position.component.toLowerCase()]?.usd,
+            mviComponentPrices[position.component.toLowerCase()]?.[VS_CURRENCY],
+            mviComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             mviPrice
           )
         })
@@ -96,7 +106,10 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            bedComponentPrices[position.component.toLowerCase()]?.usd,
+            bedComponentPrices[position.component.toLowerCase()]?.[VS_CURRENCY],
+            bedComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             bedPrice
           )
         })
@@ -109,7 +122,12 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            eth2xfliComponentPrices[position.component.toLowerCase()]?.usd,
+            eth2xfliComponentPrices[position.component.toLowerCase()]?.[
+              VS_CURRENCY
+            ],
+            eth2xfliComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             eth2xfliPrice
           )
         })
@@ -122,7 +140,12 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            btc2xfliComponentPrices[position.component.toLowerCase()]?.usd,
+            btc2xfliComponentPrices[position.component.toLowerCase()]?.[
+              VS_CURRENCY
+            ],
+            btc2xfliComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             btc2xfliPrice
           )
         })
@@ -135,7 +158,12 @@ const SetComponentsProvider: React.FC = ({ children }) => {
           return await convertPositionToSetComponent(
             position,
             tokenList,
-            dataComponentPrices[position.component.toLowerCase()]?.usd,
+            dataComponentPrices[position.component.toLowerCase()]?.[
+              VS_CURRENCY
+            ],
+            dataComponentPrices[position.component.toLowerCase()]?.[
+              `${VS_CURRENCY}_24h_change`
+            ],
             dataPrice
           )
         })
@@ -175,6 +203,7 @@ async function convertPositionToSetComponent(
   position: Position,
   tokenList: Token[],
   componentPriceUsd: number,
+  componentPriceChangeUsd: number,
   setPriceUsd: number
 ): Promise<SetComponent> {
   const token = getTokenForPosition(tokenList, position)
@@ -192,6 +221,7 @@ async function convertPositionToSetComponent(
     name: token.name,
     image: token.logoURI,
     totalPriceUsd: totalPriceUsd.toString(),
+    dailyPercentChange: componentPriceChangeUsd.toString(),
     percentOfSet: percentOfSet.toPrecision(3).toString(),
     percentOfSetNumber: percentOfSet,
   }
@@ -221,10 +251,12 @@ function sortPositionsByPercentOfSet(
   )
 }
 
-function getPositionPrices(setDetails: SetDetails): Promise<any> {
+function getPositionPrices(
+  setDetails: SetDetails
+): Promise<CoinGeckoCoinPrices> {
   const componentAddresses = setDetails.positions.map((p) => p.component)
   return fetch(
-    `https://api.coingecko.com/api/v3/simple/token_price/${ASSET_PLATFORM}?vs_currencies=${VS_CURRENCY}&contract_addresses=${componentAddresses}`
+    `https://api.coingecko.com/api/v3/simple/token_price/${ASSET_PLATFORM}?vs_currencies=${VS_CURRENCY}&contract_addresses=${componentAddresses}&include_24hr_change=true`
   )
     .then((response) => response.json())
     .catch((e) => console.error(e))


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [ ] Bug Fix
- [ ] Content
- [x] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

Re-introduce the 24 hour price change column for the underlying tokens in an index's allocation section. Work included sourcing a different data source for these values as we are no longer using the Set API that was previously used.

Feature: https://www.notion.so/index-coop/re-enable-the-24h-price-change-for-underlying-product-tokens-in-the-index-app-2521a7eee50b4536b8f2b40531b4f845

&nbsp;

## **Test Data or Screenshots**


<img width="622" alt="Screen Shot 2021-12-05 at 11 46 53 AM" src="https://user-images.githubusercontent.com/13758946/144730371-470277e5-3c08-408f-a48e-6bb51df01c10.png">
<img width="402" alt="Screen Shot 2021-12-05 at 11 46 25 AM" src="https://user-images.githubusercontent.com/13758946/144730375-42fe054b-2c8a-49f1-a46c-779645986652.png">

&nbsp;

## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
