### PR TITLE
ETH2x-FLI-P Market Cap & Price Chart Display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { Eth2xFliTokenMarketDataProvider } from 'contexts/Eth2xFliTokenMarketDat
 import { Eth2xFliTokenSupplyCapProvider } from 'contexts/Eth2xFliTokenSupplyCap'
 import { Btc2xFliTokenMarketDataProvider } from 'contexts/Btc2xFliTokenMarketData'
 import { Btc2xFliTokenSupplyCapProvider } from 'contexts/Btc2xFliTokenSupplyCap'
+import { Eth2xFLIPTokenMarketDataProvider } from 'contexts/Eth2xFLIPTokenMarketData'
+import { Eth2xFLIPTokenSupplyCapProvider } from 'contexts/Eth2xFLIPTokenSupplyCap'
 import { DpiTokenMarketDataProvider } from 'contexts/DpiTokenMarketData'
 import { MviTokenMarketDataProvider } from 'contexts/MviTokenMarketData'
 import { IndexTokenMarketDataProvider } from 'contexts/IndexTokenMarketData'
@@ -146,33 +148,37 @@ const Providers: React.FC = ({ children }) => {
                         <MviStakingRewardsProvider>
                           <PricesProvider>
                             <BuySellProvider>
-                              <Eth2xFliTokenMarketDataProvider>
-                                <Eth2xFliTokenSupplyCapProvider>
-                                  <Btc2xFliTokenMarketDataProvider>
-                                    <Btc2xFliTokenSupplyCapProvider>
-                                      <DpiTokenMarketDataProvider>
-                                        <MviTokenMarketDataProvider>
-                                          <BedTokenMarketDataProvider>
-                                            <DataTokenMarketDataProvider>
-                                              <IndexTokenMarketDataProvider>
-                                                <V3FarmingProvider>
-                                                  <StreamingFeeProvider>
-                                                    <TokenSupplyProvider>
-                                                      <SetComponentsProvider>
-                                                        {children}
-                                                      </SetComponentsProvider>
-                                                    </TokenSupplyProvider>
-                                                  </StreamingFeeProvider>
-                                                </V3FarmingProvider>
-                                              </IndexTokenMarketDataProvider>
-                                            </DataTokenMarketDataProvider>
-                                          </BedTokenMarketDataProvider>
-                                        </MviTokenMarketDataProvider>
-                                      </DpiTokenMarketDataProvider>
-                                    </Btc2xFliTokenSupplyCapProvider>
-                                  </Btc2xFliTokenMarketDataProvider>
-                                </Eth2xFliTokenSupplyCapProvider>
-                              </Eth2xFliTokenMarketDataProvider>
+                              <Eth2xFLIPTokenMarketDataProvider>
+                                <Eth2xFLIPTokenSupplyCapProvider>
+                                  <Eth2xFliTokenMarketDataProvider>
+                                    <Eth2xFliTokenSupplyCapProvider>
+                                      <Btc2xFliTokenMarketDataProvider>
+                                        <Btc2xFliTokenSupplyCapProvider>
+                                          <DpiTokenMarketDataProvider>
+                                            <MviTokenMarketDataProvider>
+                                              <BedTokenMarketDataProvider>
+                                                <DataTokenMarketDataProvider>
+                                                  <IndexTokenMarketDataProvider>
+                                                    <V3FarmingProvider>
+                                                      <StreamingFeeProvider>
+                                                        <TokenSupplyProvider>
+                                                          <SetComponentsProvider>
+                                                            {children}
+                                                          </SetComponentsProvider>
+                                                        </TokenSupplyProvider>
+                                                      </StreamingFeeProvider>
+                                                    </V3FarmingProvider>
+                                                  </IndexTokenMarketDataProvider>
+                                                </DataTokenMarketDataProvider>
+                                              </BedTokenMarketDataProvider>
+                                            </MviTokenMarketDataProvider>
+                                          </DpiTokenMarketDataProvider>
+                                        </Btc2xFliTokenSupplyCapProvider>
+                                      </Btc2xFliTokenMarketDataProvider>
+                                    </Eth2xFliTokenSupplyCapProvider>
+                                  </Eth2xFliTokenMarketDataProvider>
+                                </Eth2xFLIPTokenSupplyCapProvider>
+                              </Eth2xFLIPTokenMarketDataProvider>
                             </BuySellProvider>
                           </PricesProvider>
                         </MviStakingRewardsProvider>

--- a/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
+++ b/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
@@ -29,10 +29,14 @@ const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
   const selectLatestMarketData = (marketData?: number[][]) =>
     marketData?.[marketData.length - 1]?.[1] || 0
 
+  // TODO: Replace this data with Coingecko data once available
+  // TOOD: correctly format prices and hourly prices via TokenSets API until Coingecko data is available
   return (
     <MarketDataContext.Provider
       value={{
         ...fliMarketData,
+        prices: fliMarketData,
+        hourlyPrices: fliMarketData,
         latestMarketCap: fliMarketCapData,
         latestPrice: selectLatestMarketData(fliMarketData),
         latestVolume: 0,

--- a/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
+++ b/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
@@ -13,7 +13,7 @@ const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
   useEffect(() => {
     fetchHistoricalTokenMarketData(Ethereum2xFLIP.tokensetsId)
       .then((response: any) => {
-        setFliMarketData(response)
+        setFliMarketData(response?.prices)
       })
       .catch((error: any) => console.log(error))
   }, [])
@@ -34,8 +34,8 @@ const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
       value={{
         ...fliMarketData,
         latestMarketCap: fliMarketCapData,
-        latestPrice: selectLatestMarketData(fliMarketData?.hourlyPrices),
-        latestVolume: selectLatestMarketData(fliMarketData?.volumes),
+        latestPrice: selectLatestMarketData(fliMarketData),
+        latestVolume: 0,
       }}
     >
       {children}

--- a/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
+++ b/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
@@ -7,7 +7,7 @@ import {
 } from 'utils/tokensetsApi'
 
 const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
-  const [fliMarketData, setFliMarketData] = useState<any>({})
+  const [fliMarketData, setFliMarketData] = useState<any>([[]])
   const [fliMarketCapData, setFliMarketCapData] = useState<any>({})
 
   useEffect(() => {

--- a/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
+++ b/src/contexts/Eth2xFLIPTokenMarketData/Eth2xFLIPTokenMarketDataProvider.tsx
@@ -1,15 +1,27 @@
 import React, { useState, useEffect } from 'react'
 import MarketDataContext from './Eth2xFLIPTokenMarketDataContext'
 import { Ethereum2xFLIP } from 'constants/productTokens'
-import { fetchHistoricalTokenMarketData } from 'utils/coingeckoApi'
+import {
+  fetchHistoricalTokenMarketData,
+  fetchSetComponentsBeta,
+} from 'utils/tokensetsApi'
 
 const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
   const [fliMarketData, setFliMarketData] = useState<any>({})
+  const [fliMarketCapData, setFliMarketCapData] = useState<any>({})
 
   useEffect(() => {
-    fetchHistoricalTokenMarketData(Ethereum2xFLIP.coingeckoId)
+    fetchHistoricalTokenMarketData(Ethereum2xFLIP.tokensetsId)
       .then((response: any) => {
         setFliMarketData(response)
+      })
+      .catch((error: any) => console.log(error))
+  }, [])
+
+  useEffect(() => {
+    fetchSetComponentsBeta(Ethereum2xFLIP.tokensetsId)
+      .then((response: any) => {
+        setFliMarketCapData(response?.marketCap)
       })
       .catch((error: any) => console.log(error))
   }, [])
@@ -21,7 +33,7 @@ const Eth2xFLIPMarketDataProvider: React.FC = ({ children }) => {
     <MarketDataContext.Provider
       value={{
         ...fliMarketData,
-        latestMarketCap: selectLatestMarketData(fliMarketData?.marketcaps),
+        latestMarketCap: fliMarketCapData,
         latestPrice: selectLatestMarketData(fliMarketData?.hourlyPrices),
         latestVolume: selectLatestMarketData(fliMarketData?.volumes),
       }}

--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -83,20 +83,6 @@ const PricesProvider: React.FC = ({ children }) => {
       .catch((error) => console.log(error))
   }, [])
 
-  // useEffect(() => {
-  //   const coingeckoIndexPriceUrl = `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${indexTokenAddress}&vs_currencies=usd`
-
-  //   fetch(coingeckoIndexPriceUrl)
-  //     .then((response) => response.json())
-  //     .then((response) => {
-  //       const formattedIndexTokenAddress = indexTokenAddress?.toLowerCase()
-  //       const indexPrices = response[formattedIndexTokenAddress as string]
-  //       const indexUsdPrice = indexPrices.usd
-  //       setIndexPrice(indexUsdPrice)
-  //     })
-  //     .catch((error) => console.log(error))
-  // }, [])
-
   useEffect(() => {
     const productAddresses = [
       dpiTokenAddress,

--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -83,19 +83,19 @@ const PricesProvider: React.FC = ({ children }) => {
       .catch((error) => console.log(error))
   }, [])
 
-  useEffect(() => {
-    const coingeckoIndexPriceUrl = `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${indexTokenAddress}&vs_currencies=usd`
+  // useEffect(() => {
+  //   const coingeckoIndexPriceUrl = `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${indexTokenAddress}&vs_currencies=usd`
 
-    fetch(coingeckoIndexPriceUrl)
-      .then((response) => response.json())
-      .then((response) => {
-        const formattedIndexTokenAddress = indexTokenAddress?.toLowerCase()
-        const indexPrices = response[formattedIndexTokenAddress as string]
-        const indexUsdPrice = indexPrices.usd
-        setIndexPrice(indexUsdPrice)
-      })
-      .catch((error) => console.log(error))
-  }, [])
+  //   fetch(coingeckoIndexPriceUrl)
+  //     .then((response) => response.json())
+  //     .then((response) => {
+  //       const formattedIndexTokenAddress = indexTokenAddress?.toLowerCase()
+  //       const indexPrices = response[formattedIndexTokenAddress as string]
+  //       const indexUsdPrice = indexPrices.usd
+  //       setIndexPrice(indexUsdPrice)
+  //     })
+  //     .catch((error) => console.log(error))
+  // }, [])
 
   useEffect(() => {
     const productAddresses = [
@@ -106,6 +106,7 @@ const PricesProvider: React.FC = ({ children }) => {
       eth2xflipTokenAddress,
       btc2xfliTokenAddress,
       dataTokenAddress,
+      indexTokenAddress,
     ]
     const coinGeckoPriceUrl = `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${productAddresses}&vs_currencies=usd`
 
@@ -125,6 +126,7 @@ const PricesProvider: React.FC = ({ children }) => {
           response[btc2xfliTokenAddress?.toLowerCase() as string].usd
         )
         setDataPrice(response[dataTokenAddress?.toLowerCase() as string].usd)
+        setIndexPrice(response[indexTokenAddress?.toLowerCase() as string].usd)
       })
       .catch((error) => console.error(error))
   }, [])

--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -8,7 +8,6 @@ import {
   eth2xfliTokenAddress,
   btc2xfliTokenAddress,
   dataTokenAddress,
-  eth2xflipTokenAddress,
 } from 'constants/ethContractAddresses'
 
 import PricesContext from './PricesContext'
@@ -83,13 +82,26 @@ const PricesProvider: React.FC = ({ children }) => {
       .catch((error) => console.log(error))
   }, [])
 
+  // TODO: Remove this logic. Replace it with coingecko sourced data once available.
+  // Author: @controtie
+
+  useEffect(() => {
+    fetch('https://api.tokensets.com/public/v2/portfolios/eth2x-fli-p')
+      .then((response) => response.json())
+      .then((response) => {
+        console.log('response', response)
+        console.log('price', response?.portfolio.price_usd)
+        setEth2xflipPrice(response?.portfolio.price_usd || 0)
+      })
+      .catch((error) => console.log(error))
+  }, [])
+
   useEffect(() => {
     const productAddresses = [
       dpiTokenAddress,
       mviTokenAddress,
       bedTokenAddress,
       eth2xfliTokenAddress,
-      eth2xflipTokenAddress,
       btc2xfliTokenAddress,
       dataTokenAddress,
       indexTokenAddress,
@@ -104,9 +116,6 @@ const PricesProvider: React.FC = ({ children }) => {
         setBedPrice(response[bedTokenAddress?.toLowerCase() as string].usd)
         setEth2xfliPrice(
           response[eth2xfliTokenAddress?.toLowerCase() as string].usd
-        )
-        setEth2xflipPrice(
-          response[eth2xflipTokenAddress?.toLowerCase() as string].usd
         )
         setBtc2xfliPrice(
           response[btc2xfliTokenAddress?.toLowerCase() as string].usd

--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -83,14 +83,10 @@ const PricesProvider: React.FC = ({ children }) => {
   }, [])
 
   // TODO: Remove this logic. Replace it with coingecko sourced data once available.
-  // Author: @controtie
-
   useEffect(() => {
     fetch('https://api.tokensets.com/public/v2/portfolios/eth2x-fli-p')
       .then((response) => response.json())
       .then((response) => {
-        console.log('response', response)
-        console.log('price', response?.portfolio.price_usd)
         setEth2xflipPrice(response?.portfolio.price_usd || 0)
       })
       .catch((error) => console.log(error))

--- a/src/utils/tokensetsApi.ts
+++ b/src/utils/tokensetsApi.ts
@@ -1,0 +1,86 @@
+import { camelCase } from 'lodash'
+
+const tokensetsUrl = process.env.REACT_APP_TOKENSETS_URL
+
+export const fetchSetComponents = (set: string) => {
+  const requestUrl = `${tokensetsUrl}/public/v2/portfolios/${set}`
+
+  return fetch(requestUrl)
+    .then((response) => response.json())
+    .then((response) => {
+      if (!response?.portfolio?.components) {
+        // undocumented API endpoint. Throw error if not expected response format
+        throw new Error('Invalid API response from Set Protocol service')
+      }
+      const {
+        portfolio: { components },
+      } = response
+
+      return formatComponents(components)
+    })
+    .catch((error) => console.log(error))
+}
+
+export const fetchHistoricalTokenMarketData = (
+  id: string,
+  baseCurrency = 'usd'
+) => {
+  const requestUrl = `${tokensetsUrl}/v2/fund_historicals/${id}?currency=${baseCurrency}&beta=true&interval=month`
+
+  return fetch(requestUrl)
+    .then((response) => response.json())
+    .then((response) => {
+      const { prices, dates } = response
+      return {
+        prices: prices.map((item: any, index: number) => [dates[index], item]),
+      }
+    })
+    .catch((error) => console.log(error))
+}
+
+export const fetchSetComponentsBeta = (set: string) => {
+  const requestUrl = `${tokensetsUrl}/v2/funds/${set}?beta=true`
+
+  return fetch(requestUrl)
+    .then((response) => response.json())
+    .then((response) => {
+      if (!response?.fund?.components) {
+        // undocumented API endpoint. Throw error if not expected response format
+        throw new Error('Invalid API response from Set Protocol service')
+      }
+      const {
+        fund: {
+          components,
+          market_cap: marketCap,
+          id,
+          name,
+          symbol,
+          address,
+          image,
+        },
+      } = response
+      return {
+        components: formatComponents(components),
+        marketCap,
+        id,
+        name,
+        symbol,
+        address,
+        image,
+      }
+    })
+    .catch((error) => console.log(error))
+}
+
+function formatComponents(components: any) {
+  return components.map((component: any) => {
+    const camelCasedComponent = Object.keys(component).reduce(
+      (comp: any, k: string) => ({
+        ...comp,
+        [camelCase(k)]: component[k],
+      }),
+      {}
+    )
+    return camelCasedComponent
+  })
+}


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [ ] Bug Fix
- [ ] Content
- [x] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**
Coingecko does not currently support fetching market cap data or price chart data for polygon assets. Until that support is added, we will use tokensets API to source this data. This PR implements data fetching for price chart + market cap data.

## **Test Data or Screenshots**
![image](https://user-images.githubusercontent.com/7955024/145371888-17697fd9-b3f9-4552-9897-fa3563465542.png)


## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
