### PR TITLE
added prompt to switch networks on the buy/sell widget

### DIFF
--- a/src/components/BuySell/BuySellDisabled.tsx
+++ b/src/components/BuySell/BuySellDisabled.tsx
@@ -1,11 +1,26 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { TokenDataProps } from 'components/ProductPage/ProductDataUI'
 import useChainData from 'hooks/useChainData'
+import { MAINNET_CHAIN_DATA, POLYGON_CHAIN_DATA } from 'utils/connectors'
+import { RoundedButton } from 'components/RoundedButton'
+import { Spacer } from 'react-neu'
 
 const BuySellDisabled = (props: { tokenData: TokenDataProps }) => {
-  const { chain } = useChainData()
+  const [buttonText, setButtonText] = useState<string>('Switch to Polygon')
+  const { chain, setMainnet, setPolygon } = useChainData()
+
+  const switchNetwork = () => {
+    if (chain === MAINNET_CHAIN_DATA) setPolygon()
+    else if (chain === POLYGON_CHAIN_DATA) setMainnet()
+  }
+
+  useEffect(() => {
+    if (chain === POLYGON_CHAIN_DATA) setButtonText('Switch to Mainnet')
+    else setButtonText('Switch to Polygon')
+  }, [chain])
+
   return (
     <StyledBuySellCard data-cy='buy-sell-selector'>
       <StyledBuySellCardContent>
@@ -13,6 +28,8 @@ const BuySellDisabled = (props: { tokenData: TokenDataProps }) => {
           Purchasing {props.tokenData.token.name} on {chain.name} is currently
           not supported.
         </div>
+        <Spacer />
+        <RoundedButton text={buttonText} onClick={switchNetwork} />
       </StyledBuySellCardContent>
     </StyledBuySellCard>
   )


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [ ] Bug Fix
- [ ] Content
- [x] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

When shown that buying/selling a token is unavailable on the current network, the user is given a prompt to switch networks

&nbsp;

## **Test Data or Screenshots**

<img width="319" alt="Screen Shot 2021-12-10 at 8 24 32 AM" src="https://user-images.githubusercontent.com/7647623/145581653-e954735c-a588-4af8-81e3-7e4571d3dbc1.png">
<img width="329" alt="Screen Shot 2021-12-10 at 8 24 46 AM" src="https://user-images.githubusercontent.com/7647623/145581664-cbac47b8-a2de-44d5-884f-30843f79a2ec.png">

&nbsp;

## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
