### PR TITLE
Update INDEX logo in wallet modal

### DIFF
--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -12,9 +12,9 @@ import {
 } from 'react-neu'
 import { toast } from 'react-toastify'
 
-import numeral from 'numeral'
 import styled from 'styled-components'
 
+import indexToken from 'assets/index-token.png'
 import bedBorderLogo from 'assets/bed-border.png'
 import dataLogo from 'assets/data-logo.png'
 import Modal from 'components/CustomModal'
@@ -25,7 +25,6 @@ import { dpiTokenImage } from 'constants/productTokens'
 import useBalances from 'hooks/useBalances'
 import useWallet from 'hooks/useWallet'
 import { displayFromWei, getBigNumber } from 'utils'
-import BigNumber from 'utils/bignumber'
 import { MAINNET_CHAIN_DATA, POLYGON_CHAIN_DATA } from 'utils/connectors'
 
 const WalletModal: React.FC<ModalProps> = ({ isOpen, onDismiss }) => {
@@ -97,8 +96,8 @@ const WalletModal: React.FC<ModalProps> = ({ isOpen, onDismiss }) => {
           <Box row>
             <FancyValue
               icon={{
-                alt: 'Owl',
-                src: 'https://index-dao.s3.amazonaws.com/owl.png',
+                src: indexToken,
+                alt: 'Index token'
               }}
               link={`https://etherscan.io/address/${tokenAddresses.indexTokenAddress}`}
               label='INDEX balance'


### PR DESCRIPTION
Description
- I missed an instance of the old INDEX logo in the wallet modal during
  https://github.com/SetProtocol/index-ui/pull/555

Before | After
--- | ---
<img width="636" alt="before" src="https://user-images.githubusercontent.com/3699047/146651592-ee08efc5-5512-4e8c-8e63-7e9f4d75202e.png"> | <img width="636" alt="after" src="https://user-images.githubusercontent.com/3699047/146651599-1b6918a2-5afe-440b-b539-43ff13ec8755.png">

