### PR TITLE
Fetch ETHFLI-P components via set.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^4.0.0",
     "@davatar/react": "^1.8.1",
+    "@indexcoop/tokenlists": "^1.7.0",
     "@ledgerhq/hw-app-eth": "^6.17.0",
     "@ledgerhq/hw-transport": "^6.10.0",
     "@ledgerhq/hw-transport-webusb": "^6.11.2",

--- a/src/contexts/SetComponents/SetComponentsProvider.tsx
+++ b/src/contexts/SetComponents/SetComponentsProvider.tsx
@@ -35,7 +35,6 @@ const ASSET_PLATFORM = 'ethereum'
 const VS_CURRENCY = 'usd'
 
 const SetComponentsProvider: React.FC = ({ children }) => {
-  const { tokenList } = useTokenList()
   const {
     dpiPrice,
     mviPrice,
@@ -61,6 +60,7 @@ const SetComponentsProvider: React.FC = ({ children }) => {
   )
   const [dataComponents, setDataComponents] = useState<SetComponent[]>([])
   const { ethereum: provider, chainId } = useWallet()
+  const { tokenList } = useTokenList(chainId)
 
   useEffect(() => {
     if (

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 
+import { MaticTokens } from '@indexcoop/tokenlists'
+
 // CoinGecko ocassionaly throws 429s. We can temporarily mitigate by using
 // ONE_INCH_LIST instead however that doesn't contain some recent MVI additions
 // (e.g. WHALE)
@@ -35,14 +37,19 @@ export const fetchTokens = async (): Promise<Token[]> => {
   }
 }
 
-export function useTokenList() {
+export function useTokenList(chainId: number = 1) {
   const [tokenList, setTokenList] = useState<Token[]>()
 
   useEffect(() => {
+    if (chainId === 137) {
+      setTokenList(MaticTokens)
+      return
+    }
+
     fetchTokens().then((data) => {
       setTokenList(data)
     })
-  }, [])
+  }, [chainId])
 
   return { tokenList }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,6 +2091,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
+"@indexcoop/tokenlists@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@indexcoop/tokenlists/-/tokenlists-1.7.0.tgz#421ce4ccc3e46130dd5f3b424e9ce1eda159cff7"
+  integrity sha512-7mXUGuIs4wMSzKGvbQA5mfy38tm24U8DLGFzmPfxMIKTXiRafbH0VeQBR+wDNDGjPJbbHTYe9Bd3frr8d037zA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"


### PR DESCRIPTION
## **Type of Change**

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

## **Summary of Changes**
Fixes the allocations for ETH2x-FLI-P. Fetching of data is now done with set.js library. [Ticket](https://www.notion.so/index-coop/IndexUI-Fetch-ETH2x-FLI-P-Set-Components-via-SetJS-c7acea16f59c43f5adacc352a4f649b2)

* Adds @indexcoop/tokenlists (to use MaticTokens list)

&nbsp;

## **Test Data or Screenshots**

Tests all passing. ✅ 

<img width="811" alt="Bildschirmfoto 2022-01-07 um 11 18 53" src="https://user-images.githubusercontent.com/2104965/148573388-5f7f3104-f1a0-429a-9c2e-daec71cc66aa.png">

&nbsp;

## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.


