### PR TITLE
useMemo should cut out a lot of recalculations

### DIFF
--- a/src/contexts/Prices/PricesProvider.tsx
+++ b/src/contexts/Prices/PricesProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { useQuery } from '@apollo/react-hooks'
 
@@ -214,7 +214,7 @@ const PricesProvider: React.FC = ({ children }) => {
   }, [usdInEthMviPool, indexPrice, ethereum, totalSupplyInEthMviPool])
 
   // GMI staking Emissions
-  useEffect(() => {
+  useMemo(() => {
     if (
       !indexPrice ||
       !gmiPrice ||
@@ -235,14 +235,7 @@ const PricesProvider: React.FC = ({ children }) => {
         .multipliedBy(new BigNumber(1200))
         .toFixed(2)
     )
-  }, [
-    gmiStakingRewardsAddress,
-    indexPrice,
-    ethereum,
-    gmiPrice,
-    gmiTotalSupply,
-    gmiRewardsForDuration,
-  ])
+  }, [gmiStakingRewardsAddress, ethereum])
 
   const totalUSDInFarms =
     Number(usdInEthMviPool || '0') + Number(usdInEthDpiPool || '0')


### PR DESCRIPTION
# **Pull Request Template**

## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [x] Bug Fix
- [ ] Content
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

Memoized the callback for calculating the APR for GMI staking, should reduce recalculation which was causing performance issues.

&nbsp;

### **Fixes: Issue #**

&nbsp;

## **Test Data or Screenshots**

###### _Include proof that your changes function properly and resolve the linked issue._

&nbsp;

## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
